### PR TITLE
mqnic_i2c: Fix device_attach() error handling

### DIFF
--- a/modules/mqnic/mqnic_i2c.c
+++ b/modules/mqnic/mqnic_i2c.c
@@ -96,6 +96,7 @@ static struct i2c_client *create_i2c_client(struct i2c_adapter *adapter, const c
 {
     struct i2c_client *client;
     struct i2c_board_info board_info;
+    int err;
 
     if (!adapter)
         return NULL;
@@ -115,9 +116,15 @@ static struct i2c_client *create_i2c_client(struct i2c_adapter *adapter, const c
         return NULL;
 
     // force driver load (mainly for muxes so we can talk to downstream devices)
-    device_attach(&client->dev);
+    err = device_attach(&client->dev);
+    if (err < 0)
+	    goto err_free_client;
 
     return client;
+
+err_free_client:
+    i2c_unregister_device(client);
+    return NULL;
 }
 
 static struct i2c_adapter *get_i2c_mux_channel(struct i2c_client *mux, u32 chan_id)


### PR DESCRIPTION
If the device_attach() function fails, make sure "client" is free'd and
that the create_i2c_client() function returns NULL to signal an error to
callers.

Signed-off-by: Pekka Enberg <penberg@iki.fi>