### PR TITLE
Add cmac_pad testbench

### DIFF
--- a/fpga/common/tb/cmac_pad/Makefile
+++ b/fpga/common/tb/cmac_pad/Makefile
@@ -1,0 +1,80 @@
+# Copyright 2020, The Regents of the University of California.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright notice,
+#       this list of conditions and the following disclaimer in the documentation
+#       and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS OF THE UNIVERSITY OF CALIFORNIA ''AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE REGENTS OF THE UNIVERSITY OF CALIFORNIA OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+# OF SUCH DAMAGE.
+#
+# The views and conclusions contained in the software and documentation are those
+# of the authors and should not be interpreted as representing official policies,
+# either expressed or implied, of The Regents of the University of California.
+
+TOPLEVEL_LANG = verilog
+
+SIM ?= icarus
+WAVES ?= 0
+
+COCOTB_HDL_TIMEUNIT = 1ns
+COCOTB_HDL_TIMEPRECISION = 1ps
+
+DUT      = cmac_pad
+TOPLEVEL = $(DUT)
+MODULE   = test_$(DUT)
+VERILOG_SOURCES += ../../rtl/$(DUT).v
+
+# module parameters
+export PARAM_DATA_WIDTH ?= 512
+export PARAM_KEEP_WIDTH ?= $(shell expr $(PARAM_DATA_WIDTH) / 8 )
+
+ifeq ($(SIM), icarus)
+	PLUSARGS += -fst
+
+	COMPILE_ARGS += -P $(TOPLEVEL).DATA_WIDTH=$(PARAM_DATA_WIDTH)
+	COMPILE_ARGS += -P $(TOPLEVEL).KEEP_WIDTH=$(PARAM_KEEP_WIDTH)
+
+	ifeq ($(WAVES), 1)
+		VERILOG_SOURCES += iverilog_dump.v
+		COMPILE_ARGS += -s iverilog_dump
+	endif
+else ifeq ($(SIM), verilator)
+	COMPILE_ARGS += -Wno-SELRANGE -Wno-WIDTH
+
+	COMPILE_ARGS += -GDATA_WIDTH=$(PARAM_DATA_WIDTH)
+	COMPILE_ARGS += -GKEEP_WIDTH=$(PARAM_KEEP_WIDTH)
+
+	ifeq ($(WAVES), 1)
+		COMPILE_ARGS += --trace-fst
+	endif
+endif
+
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+iverilog_dump.v:
+	echo 'module iverilog_dump();' > $@
+	echo 'initial begin' >> $@
+	echo '    $$dumpfile("$(TOPLEVEL).fst");' >> $@
+	echo '    $$dumpvars(0, $(TOPLEVEL));' >> $@
+	echo 'end' >> $@
+	echo 'endmodule' >> $@
+
+clean::
+	@rm -rf iverilog_dump.v
+	@rm -rf dump.fst $(TOPLEVEL).fst

--- a/fpga/common/tb/cmac_pad/test_cmac_pad.py
+++ b/fpga/common/tb/cmac_pad/test_cmac_pad.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+"""
+
+Copyright 2020, The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS OF THE UNIVERSITY OF CALIFORNIA ''AS
+IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE REGENTS OF THE UNIVERSITY OF CALIFORNIA OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of The Regents of the University of California.
+
+"""
+
+import itertools
+import logging
+import os
+
+import scapy.utils
+from scapy.layers.l2 import Ether
+from scapy.layers.inet import IP, UDP, TCP
+
+import cocotb_test.simulator
+import pytest
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge
+from cocotb.regression import TestFactory
+
+from cocotbext.axi import AxiStreamBus, AxiStreamFrame, AxiStreamSource, AxiStreamSink
+
+
+class TB(object):
+    def __init__(self, dut):
+        self.dut = dut
+
+        self.log = logging.getLogger("cocotb.tb")
+        self.log.setLevel(logging.DEBUG)
+
+        cocotb.fork(Clock(dut.clk, 4, units="ns").start())
+
+        self.source = AxiStreamSource(AxiStreamBus.from_prefix(dut, "s_axis"), dut.clk, dut.rst)
+        self.sink = AxiStreamSink(AxiStreamBus.from_prefix(dut, "m_axis"), dut.clk, dut.rst)
+
+    def set_idle_generator(self, generator=None):
+        if generator:
+            self.source.set_pause_generator(generator())
+
+    async def reset(self):
+        self.dut.rst.setimmediatevalue(0)
+        await RisingEdge(self.dut.clk)
+        await RisingEdge(self.dut.clk)
+        self.dut.rst <= 1
+        await RisingEdge(self.dut.clk)
+        await RisingEdge(self.dut.clk)
+        self.dut.rst <= 0
+        await RisingEdge(self.dut.clk)
+        await RisingEdge(self.dut.clk)
+
+
+async def run_test(dut, payload_lengths=None, payload_data=None, idle_inserter=None):
+
+    tb = TB(dut)
+
+    await tb.reset()
+
+    tb.set_idle_generator(idle_inserter)
+
+    test_pkts = []
+    test_frames = []
+
+    for payload in [payload_data(x) for x in payload_lengths()]:
+        test_pkt = bytearray(payload)
+
+        test_pkts.append(test_pkt)
+        test_frame = AxiStreamFrame(test_pkt)
+        test_frames.append(test_frame)
+        
+        await tb.source.send(test_frame)
+
+    for test_pkt, test_frame in zip(test_pkts, test_frames):
+        rx_frame = await tb.sink.recv()
+
+        rx_pkt = bytes(rx_frame)
+
+        tb.log.info("RX packet: %s", repr(rx_pkt))
+
+        # padded to 60 if the packet size is less than 60
+        if len(test_pkt) < 60:
+            padded_pkt = test_pkt + bytearray([0]*(60-len(test_pkt)))
+            assert rx_frame.tdata == padded_pkt
+        else:
+            assert rx_frame.tdata == test_pkt
+
+    assert tb.sink.empty()
+
+    await RisingEdge(dut.clk)
+    await RisingEdge(dut.clk)
+
+
+def cycle_pause():
+    return itertools.cycle([1, 1, 1, 0])
+
+
+def size_list():
+    return list(range(1, 129))
+
+
+def incrementing_payload(length):
+    return bytes(itertools.islice(itertools.cycle(range(256)), length))
+
+
+if cocotb.SIM_NAME:
+
+    factory = TestFactory(run_test)
+    factory.add_option("payload_lengths", [size_list])
+    factory.add_option("payload_data", [incrementing_payload])
+    factory.add_option("idle_inserter", [None, cycle_pause])
+    factory.generate_tests()
+
+
+# cocotb-test
+
+tests_dir = os.path.dirname(__file__)
+rtl_dir = os.path.abspath(os.path.join(tests_dir, '..', '..', 'rtl'))
+lib_dir = os.path.abspath(os.path.join(rtl_dir, '..', 'lib'))
+axi_rtl_dir = os.path.abspath(os.path.join(lib_dir, 'axi', 'rtl'))
+axis_rtl_dir = os.path.abspath(os.path.join(lib_dir, 'axis', 'rtl'))
+eth_rtl_dir = os.path.abspath(os.path.join(lib_dir, 'eth', 'rtl'))
+pcie_rtl_dir = os.path.abspath(os.path.join(lib_dir, 'pcie', 'rtl'))
+
+
+def test_cmac_pad(request):
+    dut = "cmac_pad"
+    module = os.path.splitext(os.path.basename(__file__))[0]
+    toplevel = dut
+
+    verilog_sources = [
+        os.path.join(rtl_dir, f"{dut}.v"),
+    ]
+
+    parameters = {}
+
+    parameters['DATA_WIDTH'] = 512
+    parameters['KEEP_WIDTH'] = parameters['DATA_WIDTH'] // 8
+
+    extra_env = {f'PARAM_{k}': str(v) for k, v in parameters.items()}
+
+    sim_build = os.path.join(tests_dir, "sim_build",
+        request.node.name.replace('[', '-').replace(']', ''))
+
+    cocotb_test.simulator.run(
+        python_search=[tests_dir],
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        parameters=parameters,
+        sim_build=sim_build,
+        extra_env=extra_env,
+    )


### PR DESCRIPTION
Add testbench code for `cmac_pad` module. It includes two tests: `run_test_padding` and `run_test_tkeep`.

`run_test_padding` tests whether the size of the first packet is padded to 60.

`run_test_tkeep` tests whether `tdata` is masked well by `tkeep`.