### PR TITLE
use default_nettype none in corundum verilog files

### DIFF
--- a/fpga/app/template/rtl/mqnic_app_block.v
+++ b/fpga/app/template/rtl/mqnic_app_block.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Application block
@@ -587,3 +588,4 @@ assign m_axis_stat_tid = 0;
 assign m_axis_stat_tvalid = 1'b0;
 
 endmodule
+`resetall

--- a/fpga/common/rtl/cmac_pad.v
+++ b/fpga/common/rtl/cmac_pad.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * CMAC frame pad module
@@ -112,3 +113,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/cpl_op_mux.v
+++ b/fpga/common/rtl/cpl_op_mux.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Completion operation mux
@@ -283,3 +284,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/cpl_queue_manager.v
+++ b/fpga/common/rtl/cpl_queue_manager.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Completion queue manager
@@ -715,3 +716,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/cpl_write.v
+++ b/fpga/common/rtl/cpl_write.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Completion write module
@@ -589,3 +590,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/desc_fetch.v
+++ b/fpga/common/rtl/desc_fetch.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Descriptor fetch module
@@ -669,3 +670,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/desc_op_mux.v
+++ b/fpga/common/rtl/desc_op_mux.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Descriptor operation mux
@@ -434,3 +435,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/event_mux.v
+++ b/fpga/common/rtl/event_mux.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Event mux
@@ -212,3 +213,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/mqnic_core.v
+++ b/fpga/common/rtl/mqnic_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -3789,3 +3790,4 @@ end
 endgenerate
 
 endmodule
+`resetall

--- a/fpga/common/rtl/mqnic_core_pcie.v
+++ b/fpga/common/rtl/mqnic_core_pcie.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1605,3 +1606,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/common/rtl/mqnic_core_pcie_us.v
+++ b/fpga/common/rtl/mqnic_core_pcie_us.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -967,3 +968,4 @@ core_pcie_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/common/rtl/mqnic_interface.v
+++ b/fpga/common/rtl/mqnic_interface.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * NIC Interface
@@ -2363,3 +2364,4 @@ generate
 endgenerate
 
 endmodule
+`resetall

--- a/fpga/common/rtl/mqnic_port.v
+++ b/fpga/common/rtl/mqnic_port.v
@@ -1268,7 +1268,7 @@ if (RX_HASH_ENABLE) begin
 end else begin
 
     assign rx_fifo_hash = 32'd0;
-    assign rx_fifo_type = 4'd0;
+    assign rx_fifo_hash_type = 4'd0;
     assign rx_fifo_hash_valid = 1'b0;
 
 end

--- a/fpga/common/rtl/mqnic_port.v
+++ b/fpga/common/rtl/mqnic_port.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * NIC Port
@@ -1784,3 +1785,4 @@ dma_client_axis_sink_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/common/rtl/mqnic_ptp.v
+++ b/fpga/common/rtl/mqnic_ptp.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * PTP hardware clock
@@ -229,3 +230,4 @@ end
 endgenerate
 
 endmodule
+`resetall

--- a/fpga/common/rtl/mqnic_ptp_clock.v
+++ b/fpga/common/rtl/mqnic_ptp_clock.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * PTP hardware clock
@@ -242,3 +243,4 @@ ptp_clock_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/common/rtl/mqnic_ptp_perout.v
+++ b/fpga/common/rtl/mqnic_ptp_perout.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * PTP period output
@@ -201,3 +202,4 @@ ptp_perout_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/common/rtl/mqnic_tx_scheduler_block_rr.v
+++ b/fpga/common/rtl/mqnic_tx_scheduler_block_rr.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * TX scheduler block (round-robin)
@@ -275,3 +276,4 @@ tx_scheduler_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/common/rtl/mqnic_tx_scheduler_block_rr_tdma.v
+++ b/fpga/common/rtl/mqnic_tx_scheduler_block_rr_tdma.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * TX scheduler block (round-robin TDMA)
@@ -531,3 +532,4 @@ tx_scheduler_ctrl_tdma_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/common/rtl/queue_manager.v
+++ b/fpga/common/rtl/queue_manager.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Queue manager
@@ -691,3 +692,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/rx_checksum.v
+++ b/fpga/common/rtl/rx_checksum.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Receive checksum offload module
@@ -186,3 +187,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/rx_engine.v
+++ b/fpga/common/rtl/rx_engine.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Receive engine
@@ -987,3 +988,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/rx_hash.v
+++ b/fpga/common/rtl/rx_hash.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Receive hashing module
@@ -352,3 +353,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/stats_collect.v
+++ b/fpga/common/rtl/stats_collect.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Statistics collector
@@ -228,3 +229,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/stats_counter.v
+++ b/fpga/common/rtl/stats_counter.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Statistics counter
@@ -312,3 +313,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/stats_dma_if_pcie.v
+++ b/fpga/common/rtl/stats_dma_if_pcie.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Statistics for PCIe DMA interface
@@ -332,3 +333,4 @@ stats_collect_tx_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/common/rtl/stats_dma_latency.v
+++ b/fpga/common/rtl/stats_dma_latency.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Statistics collector
@@ -124,3 +125,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/stats_pcie_if.v
+++ b/fpga/common/rtl/stats_pcie_if.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Statistics for PCIe interface
@@ -445,3 +446,4 @@ stats_collect_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/common/rtl/stats_pcie_tlp.v
+++ b/fpga/common/rtl/stats_pcie_tlp.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Statistics for PCIe TLP traffic
@@ -200,3 +201,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/tdma_ber.v
+++ b/fpga/common/rtl/tdma_ber.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * TDMA BER module
@@ -459,3 +460,4 @@ generate
 endgenerate
 
 endmodule
+`resetall

--- a/fpga/common/rtl/tdma_ber_ch.v
+++ b/fpga/common/rtl/tdma_ber_ch.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * TDMA BER module
@@ -588,3 +589,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/tdma_scheduler.v
+++ b/fpga/common/rtl/tdma_scheduler.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * TDMA scheduler module
@@ -397,3 +398,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/tx_checksum.v
+++ b/fpga/common/rtl/tx_checksum.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Transmit checksum offload module
@@ -572,3 +573,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/tx_engine.v
+++ b/fpga/common/rtl/tx_engine.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Transmit engine
@@ -976,3 +977,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/tx_scheduler_ctrl_tdma.v
+++ b/fpga/common/rtl/tx_scheduler_ctrl_tdma.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * TDMA Transmit scheduler control module
@@ -575,3 +576,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/common/rtl/tx_scheduler_rr.v
+++ b/fpga/common/rtl/tx_scheduler_rr.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Transmit scheduler (round-robin)
@@ -887,3 +888,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/rtl/debounce_switch.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/rtl/fpga.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1926,3 +1927,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1078,3 +1079,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/rtl/fpga_core.v
@@ -242,6 +242,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/rtl/sync_signal.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/rtl/debounce_switch.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/rtl/fpga.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1890,3 +1891,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/rtl/fpga_core.v
@@ -249,6 +249,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1336,3 +1337,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/rtl/sync_signal.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/rtl/debounce_switch.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/rtl/fpga.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1906,3 +1907,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/rtl/fpga_core.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/rtl/fpga_core.v
@@ -249,6 +249,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/rtl/fpga_core.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1336,3 +1337,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/rtl/sync_signal.v
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU200/fpga_100g/rtl/debounce_switch.v
+++ b/fpga/mqnic/AU200/fpga_100g/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU200/fpga_100g/rtl/fpga.v
+++ b/fpga/mqnic/AU200/fpga_100g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -2071,3 +2072,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU200/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU200/fpga_100g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1086,3 +1087,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU200/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU200/fpga_100g/rtl/fpga_core.v
@@ -250,6 +250,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/AU200/fpga_100g/rtl/sync_signal.v
+++ b/fpga/mqnic/AU200/fpga_100g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU200/fpga_10g/rtl/debounce_switch.v
+++ b/fpga/mqnic/AU200/fpga_10g/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU200/fpga_10g/rtl/fpga.v
+++ b/fpga/mqnic/AU200/fpga_10g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -2046,3 +2047,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU200/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU200/fpga_10g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1344,3 +1345,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU200/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU200/fpga_10g/rtl/fpga_core.v
@@ -257,6 +257,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/AU200/fpga_10g/rtl/sync_signal.v
+++ b/fpga/mqnic/AU200/fpga_10g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU250/fpga_100g/rtl/debounce_switch.v
+++ b/fpga/mqnic/AU250/fpga_100g/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU250/fpga_100g/rtl/fpga.v
+++ b/fpga/mqnic/AU250/fpga_100g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -2071,3 +2072,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU250/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU250/fpga_100g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1086,3 +1087,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU250/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU250/fpga_100g/rtl/fpga_core.v
@@ -250,6 +250,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/AU250/fpga_100g/rtl/sync_signal.v
+++ b/fpga/mqnic/AU250/fpga_100g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU250/fpga_10g/rtl/debounce_switch.v
+++ b/fpga/mqnic/AU250/fpga_10g/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU250/fpga_10g/rtl/fpga.v
+++ b/fpga/mqnic/AU250/fpga_10g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -2046,3 +2047,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU250/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU250/fpga_10g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1344,3 +1345,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU250/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU250/fpga_10g/rtl/fpga_core.v
@@ -257,6 +257,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/AU250/fpga_10g/rtl/sync_signal.v
+++ b/fpga/mqnic/AU250/fpga_10g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU280/fpga_100g/rtl/fpga.v
+++ b/fpga/mqnic/AU280/fpga_100g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1952,3 +1953,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU280/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU280/fpga_100g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -970,3 +971,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU280/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU280/fpga_100g/rtl/fpga_core.v
@@ -234,6 +234,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/AU280/fpga_100g/rtl/sync_signal.v
+++ b/fpga/mqnic/AU280/fpga_100g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU280/fpga_10g/rtl/fpga.v
+++ b/fpga/mqnic/AU280/fpga_10g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1927,3 +1928,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU280/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU280/fpga_10g/rtl/fpga_core.v
@@ -241,6 +241,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/AU280/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU280/fpga_10g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1228,3 +1229,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU280/fpga_10g/rtl/sync_signal.v
+++ b/fpga/mqnic/AU280/fpga_10g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU50/fpga_100g/rtl/fpga.v
+++ b/fpga/mqnic/AU50/fpga_100g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1552,3 +1553,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU50/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU50/fpga_100g/rtl/fpga_core.v
@@ -241,6 +241,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/AU50/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU50/fpga_100g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -929,3 +930,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU50/fpga_100g/rtl/sync_signal.v
+++ b/fpga/mqnic/AU50/fpga_100g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU50/fpga_10g/rtl/fpga.v
+++ b/fpga/mqnic/AU50/fpga_10g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1622,3 +1623,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU50/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU50/fpga_10g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1131,3 +1132,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/AU50/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/AU50/fpga_10g/rtl/fpga_core.v
@@ -248,6 +248,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/AU50/fpga_10g/rtl/sync_signal.v
+++ b/fpga/mqnic/AU50/fpga_10g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/ExaNIC_X10/fpga/rtl/fpga.v
+++ b/fpga/mqnic/ExaNIC_X10/fpga/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1424,3 +1425,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ExaNIC_X10/fpga/rtl/fpga_core.v
+++ b/fpga/mqnic/ExaNIC_X10/fpga/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1106,3 +1107,4 @@ core_inst (
 assign cfg_mgmt_addr[18] = 1'b0;
 
 endmodule
+`resetall

--- a/fpga/mqnic/ExaNIC_X10/fpga/rtl/sync_signal.v
+++ b/fpga/mqnic/ExaNIC_X10/fpga/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/ExaNIC_X25/fpga_10g/rtl/fpga.v
+++ b/fpga/mqnic/ExaNIC_X25/fpga_10g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1457,3 +1458,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ExaNIC_X25/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/ExaNIC_X25/fpga_10g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1181,3 +1182,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ExaNIC_X25/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/ExaNIC_X25/fpga_10g/rtl/fpga_core.v
@@ -253,6 +253,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/ExaNIC_X25/fpga_10g/rtl/sync_signal.v
+++ b/fpga/mqnic/ExaNIC_X25/fpga_10g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/ExaNIC_X25/fpga_25g/rtl/fpga.v
+++ b/fpga/mqnic/ExaNIC_X25/fpga_25g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1461,3 +1462,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ExaNIC_X25/fpga_25g/rtl/fpga_core.v
+++ b/fpga/mqnic/ExaNIC_X25/fpga_25g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1181,3 +1182,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ExaNIC_X25/fpga_25g/rtl/fpga_core.v
+++ b/fpga/mqnic/ExaNIC_X25/fpga_25g/rtl/fpga_core.v
@@ -253,6 +253,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/ExaNIC_X25/fpga_25g/rtl/sync_signal.v
+++ b/fpga/mqnic/ExaNIC_X25/fpga_25g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/NetFPGA_SUME/fpga/rtl/debounce_switch.v
+++ b/fpga/mqnic/NetFPGA_SUME/fpga/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/NetFPGA_SUME/fpga/rtl/fpga.v
+++ b/fpga/mqnic/NetFPGA_SUME/fpga/rtl/fpga.v
@@ -412,6 +412,19 @@ always @(posedge pcie_user_clk) begin
     i2c_sda_t_reg <= i2c_sda_t_int;
 end
 
+wire sfp_1_mod_detect_int;
+wire sfp_2_mod_detect_int;
+wire sfp_3_mod_detect_int;
+wire sfp_4_mod_detect_int;
+wire sfp_1_los_int;
+wire sfp_2_los_int;
+wire sfp_3_los_int;
+wire sfp_4_los_int;
+wire sfp_1_tx_fault_int;
+wire sfp_2_tx_fault_int;
+wire sfp_3_tx_fault_int;
+wire sfp_4_tx_fault_int;
+
 sync_signal #(
     .WIDTH(14),
     .N(2)

--- a/fpga/mqnic/NetFPGA_SUME/fpga/rtl/fpga.v
+++ b/fpga/mqnic/NetFPGA_SUME/fpga/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1549,3 +1550,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/NetFPGA_SUME/fpga/rtl/fpga_core.v
+++ b/fpga/mqnic/NetFPGA_SUME/fpga/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1056,3 +1057,4 @@ core_inst (
 assign cfg_mgmt_addr[18] = 1'b0;
 
 endmodule
+`resetall

--- a/fpga/mqnic/NetFPGA_SUME/fpga/rtl/i2c_master.v
+++ b/fpga/mqnic/NetFPGA_SUME/fpga/rtl/i2c_master.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * I2C master
@@ -893,3 +894,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/NetFPGA_SUME/fpga/rtl/si5324_i2c_init.v
+++ b/fpga/mqnic/NetFPGA_SUME/fpga/rtl/si5324_i2c_init.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * si5324_i2c_init
@@ -492,3 +493,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/NetFPGA_SUME/fpga/rtl/sync_signal.v
+++ b/fpga/mqnic/NetFPGA_SUME/fpga/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU108/fpga_10g/rtl/debounce_switch.v
+++ b/fpga/mqnic/VCU108/fpga_10g/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU108/fpga_10g/rtl/fpga.v
+++ b/fpga/mqnic/VCU108/fpga_10g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1579,3 +1580,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU108/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/VCU108/fpga_10g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1175,3 +1176,4 @@ core_inst (
 assign cfg_mgmt_addr[18] = 1'b0;
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU108/fpga_10g/rtl/sync_signal.v
+++ b/fpga/mqnic/VCU108/fpga_10g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU118/fpga_100g/rtl/debounce_switch.v
+++ b/fpga/mqnic/VCU118/fpga_100g/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU118/fpga_100g/rtl/fpga.v
+++ b/fpga/mqnic/VCU118/fpga_100g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1927,3 +1928,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU118/fpga_100g/rtl/fpga.v
+++ b/fpga/mqnic/VCU118/fpga_100g/rtl/fpga.v
@@ -1884,7 +1884,7 @@ core_inst (
     .qsfp1_modsell(qsfp1_modsell),
     .qsfp1_resetl(qsfp1_resetl),
     .qsfp1_intl(qsfp1_intl_int),
-    .qsfp1_lpmode(qsfp1_lpmode_int),
+    .qsfp1_lpmode(qsfp1_lpmode),
 
     .qsfp2_tx_clk(qsfp2_tx_clk_int),
     .qsfp2_tx_rst(qsfp2_tx_rst_int),
@@ -1910,7 +1910,7 @@ core_inst (
     .qsfp2_modsell(qsfp2_modsell),
     .qsfp2_resetl(qsfp2_resetl),
     .qsfp2_intl(qsfp2_intl_int),
-    .qsfp2_lpmode(qsfp2_lpmode_int),
+    .qsfp2_lpmode(qsfp2_lpmode),
 
     /*
      * QSPI flash

--- a/fpga/mqnic/VCU118/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/VCU118/fpga_100g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1059,3 +1060,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU118/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/VCU118/fpga_100g/rtl/fpga_core.v
@@ -257,6 +257,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/VCU118/fpga_100g/rtl/sync_signal.v
+++ b/fpga/mqnic/VCU118/fpga_100g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU118/fpga_10g/rtl/debounce_switch.v
+++ b/fpga/mqnic/VCU118/fpga_10g/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU118/fpga_10g/rtl/fpga.v
+++ b/fpga/mqnic/VCU118/fpga_10g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1873,3 +1874,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU118/fpga_10g/rtl/fpga.v
+++ b/fpga/mqnic/VCU118/fpga_10g/rtl/fpga.v
@@ -1806,7 +1806,7 @@ core_inst (
     .qsfp1_modsell(qsfp1_modsell),
     .qsfp1_resetl(qsfp1_resetl),
     .qsfp1_intl(qsfp1_intl_int),
-    .qsfp1_lpmode(qsfp1_lpmode_int),
+    .qsfp1_lpmode(qsfp1_lpmode),
 
     .qsfp2_tx_clk_1(qsfp2_tx_clk_1_int),
     .qsfp2_tx_rst_1(qsfp2_tx_rst_1_int),
@@ -1856,7 +1856,7 @@ core_inst (
     .qsfp2_modsell(qsfp2_modsell),
     .qsfp2_resetl(qsfp2_resetl),
     .qsfp2_intl(qsfp2_intl_int),
-    .qsfp2_lpmode(qsfp2_lpmode_int),
+    .qsfp2_lpmode(qsfp2_lpmode),
 
     /*
      * QSPI flash

--- a/fpga/mqnic/VCU118/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/VCU118/fpga_10g/rtl/fpga_core.v
@@ -264,6 +264,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/VCU118/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/VCU118/fpga_10g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1317,3 +1318,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU118/fpga_10g/rtl/sync_signal.v
+++ b/fpga/mqnic/VCU118/fpga_10g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU1525/fpga_100g/rtl/debounce_switch.v
+++ b/fpga/mqnic/VCU1525/fpga_100g/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU1525/fpga_100g/rtl/fpga.v
+++ b/fpga/mqnic/VCU1525/fpga_100g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1905,3 +1906,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU1525/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/VCU1525/fpga_100g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1014,3 +1015,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU1525/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/VCU1525/fpga_100g/rtl/fpga_core.v
@@ -250,6 +250,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/VCU1525/fpga_100g/rtl/sync_signal.v
+++ b/fpga/mqnic/VCU1525/fpga_100g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU1525/fpga_10g/rtl/debounce_switch.v
+++ b/fpga/mqnic/VCU1525/fpga_10g/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU1525/fpga_10g/rtl/fpga.v
+++ b/fpga/mqnic/VCU1525/fpga_10g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1866,3 +1867,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU1525/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/VCU1525/fpga_10g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1272,3 +1273,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/VCU1525/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/VCU1525/fpga_10g/rtl/fpga_core.v
@@ -257,6 +257,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/VCU1525/fpga_10g/rtl/sync_signal.v
+++ b/fpga/mqnic/VCU1525/fpga_10g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/ZCU106/fpga_pcie/rtl/debounce_switch.v
+++ b/fpga/mqnic/ZCU106/fpga_pcie/rtl/debounce_switch.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes switch and button inputs with a slow sampled shift register
@@ -87,3 +88,4 @@ always @(posedge clk or posedge rst) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/ZCU106/fpga_pcie/rtl/fpga.v
+++ b/fpga/mqnic/ZCU106/fpga_pcie/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1215,3 +1216,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ZCU106/fpga_pcie/rtl/fpga_core.v
+++ b/fpga/mqnic/ZCU106/fpga_pcie/rtl/fpga_core.v
@@ -262,6 +262,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/ZCU106/fpga_pcie/rtl/fpga_core.v
+++ b/fpga/mqnic/ZCU106/fpga_pcie/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1004,3 +1005,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/ZCU106/fpga_pcie/rtl/sync_signal.v
+++ b/fpga/mqnic/ZCU106/fpga_pcie/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_100g/rtl/bmc_spi.v
+++ b/fpga/mqnic/fb2CG/fpga_100g/rtl/bmc_spi.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Board management controller interface
@@ -284,3 +285,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_100g/rtl/fpga.v
+++ b/fpga/mqnic/fb2CG/fpga_100g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1959,3 +1960,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/fb2CG/fpga_100g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1106,3 +1107,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_100g/rtl/fpga_core.v
+++ b/fpga/mqnic/fb2CG/fpga_100g/rtl/fpga_core.v
@@ -255,6 +255,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/fb2CG/fpga_100g/rtl/led_sreg_driver.v
+++ b/fpga/mqnic/fb2CG/fpga_100g/rtl/led_sreg_driver.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * LED shift register driver
@@ -133,3 +134,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_100g/rtl/sync_signal.v
+++ b/fpga/mqnic/fb2CG/fpga_100g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_10g/rtl/bmc_spi.v
+++ b/fpga/mqnic/fb2CG/fpga_10g/rtl/bmc_spi.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Board management controller interface
@@ -284,3 +285,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_10g/rtl/fpga.v
+++ b/fpga/mqnic/fb2CG/fpga_10g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1929,3 +1930,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/fb2CG/fpga_10g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1364,3 +1365,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_10g/rtl/fpga_core.v
+++ b/fpga/mqnic/fb2CG/fpga_10g/rtl/fpga_core.v
@@ -262,6 +262,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/fb2CG/fpga_10g/rtl/led_sreg_driver.v
+++ b/fpga/mqnic/fb2CG/fpga_10g/rtl/led_sreg_driver.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * LED shift register driver
@@ -133,3 +134,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_10g/rtl/sync_signal.v
+++ b/fpga/mqnic/fb2CG/fpga_10g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_25g/rtl/bmc_spi.v
+++ b/fpga/mqnic/fb2CG/fpga_25g/rtl/bmc_spi.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * Board management controller interface
@@ -284,3 +285,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_25g/rtl/fpga.v
+++ b/fpga/mqnic/fb2CG/fpga_25g/rtl/fpga.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA top-level module
@@ -1945,3 +1946,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_25g/rtl/fpga_core.v
+++ b/fpga/mqnic/fb2CG/fpga_25g/rtl/fpga_core.v
@@ -34,6 +34,7 @@ either expressed or implied, of The Regents of the University of California.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * FPGA core logic
@@ -1364,3 +1365,4 @@ core_inst (
 );
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_25g/rtl/fpga_core.v
+++ b/fpga/mqnic/fb2CG/fpga_25g/rtl/fpga_core.v
@@ -262,6 +262,7 @@ module fpga_core #
     output wire [2:0]                         cfg_fc_sel,
 
     input  wire [3:0]                         cfg_interrupt_msi_enable,
+    input  wire [7:0]                         cfg_interrupt_msi_vf_enable,
     input  wire [11:0]                        cfg_interrupt_msi_mmenable,
     input  wire                               cfg_interrupt_msi_mask_update,
     input  wire [31:0]                        cfg_interrupt_msi_data,

--- a/fpga/mqnic/fb2CG/fpga_25g/rtl/led_sreg_driver.v
+++ b/fpga/mqnic/fb2CG/fpga_25g/rtl/led_sreg_driver.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog 2001
 
 `timescale 1ns / 1ps
+`default_nettype none
 
 /*
  * LED shift register driver
@@ -133,3 +134,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall

--- a/fpga/mqnic/fb2CG/fpga_25g/rtl/sync_signal.v
+++ b/fpga/mqnic/fb2CG/fpga_25g/rtl/sync_signal.v
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // Language: Verilog-2001
 
 `timescale 1 ns / 1 ps
+`default_nettype none
 
 /*
  * Synchronizes an asyncronous signal to a given clock by using a pipeline of
@@ -56,3 +57,4 @@ always @(posedge clk) begin
 end
 
 endmodule
+`resetall


### PR DESCRIPTION
To make it somewhat simpler to detect simple wiring coding failures it makes sense to add default_nettype to all files. To not break any other functionality it is important to add resetall at the end of each file to not break other files settings if those are not that explicit (IP cores tend to do so...).

This PR just changes all the files which are located in corundum itself but not the ones in the "subtrees" to not need to update all the repos for now. To also change all those the following commands could be used:
```
cd fpga/lib
find . -name *.v -exec sed -i '/^`timescale.*/a `default_nettype none' {} \;
find . -name *.v -exec sed -i '/^endmodule.*/a `resetall' {} \;
```