### PR TITLE
Mle/tb/tox versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,15 +11,15 @@ python =
 
 [testenv]
 deps =
-    pytest
-    pytest-xdist
-    pytest-split
-    cocotb
-    cocotb-test
-    cocotbext-axi
-    cocotbext-eth
-    cocotbext-pcie
-    scapy
+    pytest == 6.2.5
+    pytest-xdist == 2.4.0
+    pytest-split == 0.4.0
+    cocotb == 1.6.0
+    cocotb-test == 0.2.1
+    cocotbext-axi == 0.1.16
+    cocotbext-eth == 0.1.18
+    cocotbext-pcie == 0.1.20
+    scapy == 2.4.5
 
 commands =
     pytest -n auto {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 [tox]
 envlist = py39
 skipsdist = True
+minversion = 3.2.0
+requires = virtualenv >= 16.1
 
 [gh-actions]
 python =


### PR DESCRIPTION
As already stated on slack we ran into issues caused by outdated tox installation.
In addition we added current package versions of the dependencies to also get failures here if the installation/pip is too old.