### PR TITLE
support more than 4k queues (workaround quartus loop iteration limit)

### DIFF
--- a/fpga/common/rtl/cpl_queue_manager.v
+++ b/fpga/common/rtl/cpl_queue_manager.v
@@ -295,11 +295,14 @@ wire queue_full_active = ($unsigned(op_table_queue_ptr[queue_ram_read_data_op_in
 wire queue_full = queue_active ? queue_full_active : queue_full_idle;
 wire [QUEUE_PTR_WIDTH-1:0] queue_ram_read_active_head_ptr = queue_active ? op_table_queue_ptr[queue_ram_read_data_op_index] : queue_ram_read_data_head_ptr;
 
-integer i;
+integer i, j;
 
 initial begin
-    for (i = 0; i < QUEUE_COUNT; i = i + 1) begin
-        queue_ram[i] = 0;
+    // break up loop to work around iteration termination
+    for (i = 0; i < QUEUE_INDEX_WIDTH; i = i + 2**(QUEUE_INDEX_WIDTH/2)) begin
+        for (j = i; j < i + 2**(QUEUE_INDEX_WIDTH/2); j = j + 1) begin
+            queue_ram[j] = 0;
+        end
     end
 
     for (i = 0; i < PIPELINE; i = i + 1) begin
@@ -315,8 +318,6 @@ initial begin
         op_table_queue_ptr[i] = 0;
     end
 end
-
-integer j;
 
 always @* begin
     op_axil_write_pipe_next = {op_axil_write_pipe_reg, 1'b0};

--- a/fpga/common/rtl/queue_manager.v
+++ b/fpga/common/rtl/queue_manager.v
@@ -296,11 +296,14 @@ wire queue_empty_active = queue_ram_read_data_head_ptr == op_table_queue_ptr[que
 wire queue_empty = queue_active ? queue_empty_active : queue_empty_idle;
 wire [QUEUE_PTR_WIDTH-1:0] queue_ram_read_active_tail_ptr = queue_active ? op_table_queue_ptr[queue_ram_read_data_op_index] : queue_ram_read_data_tail_ptr;
 
-integer i;
+integer i, j;
 
 initial begin
-    for (i = 0; i < QUEUE_COUNT; i = i + 1) begin
-        queue_ram[i] = 0;
+    // break up loop to work around iteration termination
+    for (i = 0; i < QUEUE_INDEX_WIDTH; i = i + 2**(QUEUE_INDEX_WIDTH/2)) begin
+        for (j = i; j < i + 2**(QUEUE_INDEX_WIDTH/2); j = j + 1) begin
+            queue_ram[j] = 0;
+        end
     end
 
     for (i = 0; i < PIPELINE; i = i + 1) begin
@@ -316,8 +319,6 @@ initial begin
         op_table_queue_ptr[i] = 0;
     end
 end
-
-integer j;
 
 always @* begin
     op_axil_write_pipe_next = {op_axil_write_pipe_reg, 1'b0};

--- a/fpga/common/rtl/tx_scheduler_rr.v
+++ b/fpga/common/rtl/tx_scheduler_rr.v
@@ -385,11 +385,14 @@ op_table_start_enc_inst (
     .output_unencoded()
 );
 
-integer i;
+integer i, j;
 
 initial begin
-    for (i = 0; i < QUEUE_COUNT; i = i + 1) begin
-        queue_ram[i] = 0;
+    // break up loop to work around iteration termination
+    for (i = 0; i < QUEUE_INDEX_WIDTH; i = i + 2**(QUEUE_INDEX_WIDTH/2)) begin
+        for (j = i; j < i + 2**(QUEUE_INDEX_WIDTH/2); j = j + 1) begin
+            queue_ram[j] = 0;
+        end
     end
 
     for (i = 0; i < PIPELINE; i = i + 1) begin
@@ -407,8 +410,6 @@ initial begin
         op_table_is_head[i] = 0;
     end
 end
-
-integer j;
 
 always @* begin
     op_axil_write_pipe_next = {op_axil_write_pipe_reg, 1'b0};


### PR DESCRIPTION
While creating test builds for an intel platform the RAM initialisation failes as the loop iteration limit of 5000 iterations is reached.

Let's work around this in the code as it has been done in other modules as well.