### PR TITLE
add .gitignore files in fpga build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.pyc
 *.vvp
 *.kate-swp
+/.tox/
 

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/fpga/.gitignore
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/fpga_tdma/.gitignore
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_100g/fpga_tdma/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/fpga/.gitignore
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/fpga_tdma/.gitignore
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_10g/fpga_tdma/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/fpga/.gitignore
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/fpga_tdma/.gitignore
+++ b/fpga/mqnic/ADM_PCIE_9V3/fpga_25g/fpga_tdma/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/AU200/fpga_100g/fpga/.gitignore
+++ b/fpga/mqnic/AU200/fpga_100g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/AU200/fpga_10g/fpga/.gitignore
+++ b/fpga/mqnic/AU200/fpga_10g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/AU250/fpga_100g/fpga/.gitignore
+++ b/fpga/mqnic/AU250/fpga_100g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/AU250/fpga_10g/fpga/.gitignore
+++ b/fpga/mqnic/AU250/fpga_10g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/AU280/fpga_100g/fpga/.gitignore
+++ b/fpga/mqnic/AU280/fpga_100g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/AU280/fpga_10g/fpga/.gitignore
+++ b/fpga/mqnic/AU280/fpga_10g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/AU50/fpga_100g/fpga/.gitignore
+++ b/fpga/mqnic/AU50/fpga_100g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/AU50/fpga_10g/fpga/.gitignore
+++ b/fpga/mqnic/AU50/fpga_10g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/AU50/fpga_10g/fpga_1sx040h/.gitignore
+++ b/fpga/mqnic/AU50/fpga_10g/fpga_1sx040h/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/ExaNIC_X10/fpga/fpga/.gitignore
+++ b/fpga/mqnic/ExaNIC_X10/fpga/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/ExaNIC_X25/fpga_10g/fpga/.gitignore
+++ b/fpga/mqnic/ExaNIC_X25/fpga_10g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/ExaNIC_X25/fpga_25g/fpga/.gitignore
+++ b/fpga/mqnic/ExaNIC_X25/fpga_25g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/NetFPGA_SUME/fpga/fpga/.gitignore
+++ b/fpga/mqnic/NetFPGA_SUME/fpga/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/PE/fpga_10g/fpga/.gitignore
+++ b/fpga/mqnic/PE/fpga_10g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/S10MX_DK/fpga_10g/fpga_1sm21b/.gitignore
+++ b/fpga/mqnic/S10MX_DK/fpga_10g/fpga_1sm21b/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/S10MX_DK/fpga_10g/fpga_1sm21c/.gitignore
+++ b/fpga/mqnic/S10MX_DK/fpga_10g/fpga_1sm21c/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/VCU108/fpga_10g/fpga/.gitignore
+++ b/fpga/mqnic/VCU108/fpga_10g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/VCU118/fpga_100g/fpga/.gitignore
+++ b/fpga/mqnic/VCU118/fpga_100g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/VCU118/fpga_10g/fpga/.gitignore
+++ b/fpga/mqnic/VCU118/fpga_10g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/VCU1525/fpga_100g/fpga/.gitignore
+++ b/fpga/mqnic/VCU1525/fpga_100g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/VCU1525/fpga_10g/fpga/.gitignore
+++ b/fpga/mqnic/VCU1525/fpga_10g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/ZCU106/fpga_pcie/fpga/.gitignore
+++ b/fpga/mqnic/ZCU106/fpga_pcie/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/fb2CG/fpga_100g/fpga/.gitignore
+++ b/fpga/mqnic/fb2CG/fpga_100g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/fb2CG/fpga_100g/fpga_tdma/.gitignore
+++ b/fpga/mqnic/fb2CG/fpga_100g/fpga_tdma/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/fb2CG/fpga_10g/fpga/.gitignore
+++ b/fpga/mqnic/fb2CG/fpga_10g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/fb2CG/fpga_10g/fpga_tdma/.gitignore
+++ b/fpga/mqnic/fb2CG/fpga_10g/fpga_tdma/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/fb2CG/fpga_25g/fpga/.gitignore
+++ b/fpga/mqnic/fb2CG/fpga_25g/fpga/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore

--- a/fpga/mqnic/fb2CG/fpga_25g/fpga_tdma/.gitignore
+++ b/fpga/mqnic/fb2CG/fpga_25g/fpga_tdma/.gitignore
@@ -1,0 +1,4 @@
+*
+!/Makefile
+!/config.tcl
+!/.gitignore


### PR DESCRIPTION
During the FPGA design build process a lot of temporary files are generated in the respective fpga project folders.

Let's add local _.gitignore_ files within these directories that hide these files, especially using `git gui` is otherwise almost impossible.

The alternative approach would be a 'global' _.gitignore_ file, e.g. located in the _fpga/mqnic/_ directory. However, this might be less straight-forward in case a single fpga build requires additional files to be visible.

Also the _.tox_ directory in the root of the repo directory structure is now hidden via the top level _.gitignore_ file.