### PR TITLE
Mle/mlab fix

### DIFF
--- a/fpga/common/rtl/cpl_queue_manager.v
+++ b/fpga/common/rtl/cpl_queue_manager.v
@@ -247,6 +247,10 @@ reg [OP_TABLE_SIZE-1:0] op_table_commit = 0;
 (* ram_style = "distributed", ramstyle = "no_rw_check, mlab" *)
 reg [QUEUE_INDEX_WIDTH-1:0] op_table_queue[OP_TABLE_SIZE-1:0];
 (* ram_style = "distributed", ramstyle = "no_rw_check, mlab" *)
+reg [QUEUE_INDEX_WIDTH-1:0] op_table_queue_finish[OP_TABLE_SIZE-1:0];
+reg [QUEUE_INDEX_WIDTH-1:0] op_table_queue_out_reg;
+reg [QUEUE_INDEX_WIDTH-1:0] op_table_queue_finish_out_reg;
+(* ram_style = "distributed", ramstyle = "no_rw_check, mlab" *)
 reg [QUEUE_PTR_WIDTH-1:0] op_table_queue_ptr[OP_TABLE_SIZE-1:0];
 reg [CL_OP_TABLE_SIZE-1:0] op_table_start_ptr_reg = 0;
 reg [QUEUE_INDEX_WIDTH-1:0] op_table_start_queue;
@@ -289,7 +293,7 @@ wire [2:0] s_axil_awaddr_reg = s_axil_awaddr >> 2;
 wire [QUEUE_INDEX_WIDTH-1:0] s_axil_araddr_queue = s_axil_araddr >> 5;
 wire [2:0] s_axil_araddr_reg = s_axil_araddr >> 2;
 
-wire queue_active = op_table_active[queue_ram_read_data_op_index] && op_table_queue[queue_ram_read_data_op_index] == queue_ram_addr_pipeline_reg[PIPELINE-1];
+wire queue_active = op_table_active[queue_ram_read_data_op_index] && op_table_queue_out_reg == queue_ram_addr_pipeline_reg[PIPELINE-1];
 wire queue_full_idle = ($unsigned(queue_ram_read_data_head_ptr - queue_ram_read_data_tail_ptr) & ({QUEUE_PTR_WIDTH{1'b1}} << queue_ram_read_data_log_size)) != 0;
 wire queue_full_active = ($unsigned(op_table_queue_ptr[queue_ram_read_data_op_index] - queue_ram_read_data_tail_ptr) & ({QUEUE_PTR_WIDTH{1'b1}} << queue_ram_read_data_log_size)) != 0;
 wire queue_full = queue_active ? queue_full_active : queue_full_idle;
@@ -316,6 +320,7 @@ initial begin
     for (i = 0; i < OP_TABLE_SIZE; i = i + 1) begin
         op_table_queue[i] = 0;
         op_table_queue_ptr[i] = 0;
+        op_table_queue_finish[i] = 0;
     end
 end
 
@@ -388,7 +393,7 @@ always @* begin
         op_axil_write_pipe_hazard = op_axil_write_pipe_hazard || (stage_active && queue_ram_addr_pipeline_reg[j] == s_axil_awaddr_queue);
         op_axil_read_pipe_hazard = op_axil_read_pipe_hazard || (stage_active && queue_ram_addr_pipeline_reg[j] == s_axil_araddr_queue);
         op_req_pipe_hazard = op_req_pipe_hazard || (stage_active && queue_ram_addr_pipeline_reg[j] == s_axis_enqueue_req_queue);
-        op_commit_pipe_hazard = op_commit_pipe_hazard || (stage_active && queue_ram_addr_pipeline_reg[j] == op_table_queue[op_table_finish_ptr_reg]);
+        op_commit_pipe_hazard = op_commit_pipe_hazard || (stage_active && queue_ram_addr_pipeline_reg[j] == op_table_queue_finish_out_reg);
     end
 
     // pipeline stage 0 - receive request
@@ -422,8 +427,8 @@ always @* begin
 
         write_data_pipeline_next[0] = op_table_queue_ptr[op_table_finish_ptr_reg];
 
-        queue_ram_read_ptr = op_table_queue[op_table_finish_ptr_reg];
-        queue_ram_addr_pipeline_next[0] = op_table_queue[op_table_finish_ptr_reg];
+        queue_ram_read_ptr = op_table_queue_finish_out_reg;
+        queue_ram_addr_pipeline_next[0] = op_table_queue_finish_out_reg;
     end else if (enable && !op_table_active[op_table_start_ptr_reg] && s_axis_enqueue_req_valid && (!m_axis_enqueue_resp_valid || m_axis_enqueue_resp_ready) && !op_req_pipe_reg && !op_req_pipe_hazard) begin
         // enqueue request
         op_req_pipe_next[0] = 1'b1;
@@ -627,7 +632,10 @@ always @* begin
     end
 end
 
-always @(posedge clk) begin
+always @(posedge clk) begin : queue_p
+    reg [CL_OP_TABLE_SIZE-1:0] queue_ram_read_data_op_index_var;
+    reg [CL_OP_TABLE_SIZE-1:0] op_table_finish_ptr_var;
+
     if (rst) begin
         op_axil_write_pipe_reg <= {PIPELINE{1'b0}};
         op_axil_read_pipe_reg <= {PIPELINE{1'b0}};
@@ -649,7 +657,9 @@ always @(posedge clk) begin
 
         op_table_start_ptr_reg <= 0;
         op_table_finish_ptr_reg <= 0;
+        op_table_queue_finish_out_reg <= op_table_queue_finish[0];
     end else begin
+        op_table_finish_ptr_var = op_table_finish_ptr_reg;
         op_axil_write_pipe_reg <= op_axil_write_pipe_next;
         op_axil_read_pipe_reg <= op_axil_read_pipe_next;
         op_req_pipe_reg <= op_req_pipe_next;
@@ -672,7 +682,9 @@ always @(posedge clk) begin
         end
         if (op_table_finish_en) begin
             op_table_finish_ptr_reg <= op_table_finish_ptr_reg + 1;
+            op_table_finish_ptr_var = op_table_finish_ptr_reg + 1;
             op_table_active[op_table_finish_ptr_reg] <= 1'b0;
+            op_table_queue_finish_out_reg <= op_table_queue_finish[op_table_finish_ptr_var];
         end
     end
 
@@ -710,10 +722,25 @@ always @(posedge clk) begin
         queue_ram_read_data_pipeline_reg[i] <= queue_ram_read_data_pipeline_reg[i-1];
     end
 
+    if (PIPELINE == 2) begin
+        queue_ram_read_data_op_index_var = queue_ram_read_data_reg[63:56];
+    end else begin
+        queue_ram_read_data_op_index_var = queue_ram_read_data_pipeline_reg[PIPELINE-2][63:56];
+    end
+    op_table_queue_out_reg <= op_table_queue[queue_ram_read_data_op_index_var];
+
     if (op_table_start_en) begin
         op_table_commit[op_table_start_ptr_reg] <= 1'b0;
         op_table_queue[op_table_start_ptr_reg] <= op_table_start_queue;
+        op_table_queue_finish[op_table_start_ptr_reg] <= op_table_start_queue;
         op_table_queue_ptr[op_table_start_ptr_reg] <= op_table_start_queue_ptr;
+        if (op_table_finish_ptr_var == op_table_start_ptr_reg) begin
+            op_table_queue_finish_out_reg <= op_table_start_queue;
+        end
+
+        if (op_table_start_ptr_reg == queue_ram_read_data_op_index_var) begin
+            op_table_queue_out_reg <= op_table_start_queue;
+        end
     end
     if (op_table_commit_en) begin
         op_table_commit[op_table_commit_ptr] <= 1'b1;

--- a/fpga/common/rtl/queue_manager.v
+++ b/fpga/common/rtl/queue_manager.v
@@ -248,6 +248,10 @@ reg [OP_TABLE_SIZE-1:0] op_table_commit = 0;
 (* ram_style = "distributed", ramstyle = "no_rw_check, mlab" *)
 reg [QUEUE_INDEX_WIDTH-1:0] op_table_queue[OP_TABLE_SIZE-1:0];
 (* ram_style = "distributed", ramstyle = "no_rw_check, mlab" *)
+reg [QUEUE_INDEX_WIDTH-1:0] op_table_queue_finish[OP_TABLE_SIZE-1:0];
+reg [QUEUE_INDEX_WIDTH-1:0] op_table_queue_out_reg;
+reg [QUEUE_INDEX_WIDTH-1:0] op_table_queue_finish_out_reg;
+(* ram_style = "distributed", ramstyle = "no_rw_check, mlab" *)
 reg [QUEUE_PTR_WIDTH-1:0] op_table_queue_ptr[OP_TABLE_SIZE-1:0];
 reg [CL_OP_TABLE_SIZE-1:0] op_table_start_ptr_reg = 0;
 reg [QUEUE_INDEX_WIDTH-1:0] op_table_start_queue;
@@ -290,7 +294,7 @@ wire [2:0] s_axil_awaddr_reg = s_axil_awaddr >> 2;
 wire [QUEUE_INDEX_WIDTH-1:0] s_axil_araddr_queue = s_axil_araddr >> 5;
 wire [2:0] s_axil_araddr_reg = s_axil_araddr >> 2;
 
-wire queue_active = op_table_active[queue_ram_read_data_op_index] && op_table_queue[queue_ram_read_data_op_index] == queue_ram_addr_pipeline_reg[PIPELINE-1];
+wire queue_active = op_table_active[queue_ram_read_data_op_index] && op_table_queue_out_reg == queue_ram_addr_pipeline_reg[PIPELINE-1];
 wire queue_empty_idle = queue_ram_read_data_head_ptr == queue_ram_read_data_tail_ptr;
 wire queue_empty_active = queue_ram_read_data_head_ptr == op_table_queue_ptr[queue_ram_read_data_op_index];
 wire queue_empty = queue_active ? queue_empty_active : queue_empty_idle;
@@ -317,6 +321,7 @@ initial begin
     for (i = 0; i < OP_TABLE_SIZE; i = i + 1) begin
         op_table_queue[i] = 0;
         op_table_queue_ptr[i] = 0;
+        op_table_queue_finish[i] = 0;
     end
 end
 
@@ -389,7 +394,7 @@ always @* begin
         op_axil_write_pipe_hazard = op_axil_write_pipe_hazard || (stage_active && queue_ram_addr_pipeline_reg[j] == s_axil_awaddr_queue);
         op_axil_read_pipe_hazard = op_axil_read_pipe_hazard || (stage_active && queue_ram_addr_pipeline_reg[j] == s_axil_araddr_queue);
         op_req_pipe_hazard = op_req_pipe_hazard || (stage_active && queue_ram_addr_pipeline_reg[j] == s_axis_dequeue_req_queue);
-        op_commit_pipe_hazard = op_commit_pipe_hazard || (stage_active && queue_ram_addr_pipeline_reg[j] == op_table_queue[op_table_finish_ptr_reg]);
+        op_commit_pipe_hazard = op_commit_pipe_hazard || (stage_active && queue_ram_addr_pipeline_reg[j] == op_table_queue_finish_out_reg);
     end
 
     // pipeline stage 0 - receive request
@@ -423,8 +428,8 @@ always @* begin
 
         write_data_pipeline_next[0] = op_table_queue_ptr[op_table_finish_ptr_reg];
 
-        queue_ram_read_ptr = op_table_queue[op_table_finish_ptr_reg];
-        queue_ram_addr_pipeline_next[0] = op_table_queue[op_table_finish_ptr_reg];
+        queue_ram_read_ptr = op_table_queue_finish_out_reg;
+        queue_ram_addr_pipeline_next[0] = op_table_queue_finish_out_reg;
     end else if (enable && !op_table_active[op_table_start_ptr_reg] && s_axis_dequeue_req_valid && (!m_axis_dequeue_resp_valid || m_axis_dequeue_resp_ready) && !op_req_pipe_reg && !op_req_pipe_hazard) begin
         // dequeue request
         op_req_pipe_next[0] = 1'b1;
@@ -602,7 +607,10 @@ always @* begin
     end
 end
 
-always @(posedge clk) begin
+always @(posedge clk) begin : queue_p
+    reg [CL_OP_TABLE_SIZE-1:0] queue_ram_read_data_op_index_var;
+    reg [CL_OP_TABLE_SIZE-1:0] op_table_finish_ptr_var;
+
     if (rst) begin
         op_axil_write_pipe_reg <= {PIPELINE{1'b0}};
         op_axil_read_pipe_reg <= {PIPELINE{1'b0}};
@@ -624,7 +632,9 @@ always @(posedge clk) begin
 
         op_table_start_ptr_reg <= 0;
         op_table_finish_ptr_reg <= 0;
+        op_table_queue_finish_out_reg <= op_table_queue_finish[0];
     end else begin
+        op_table_finish_ptr_var = op_table_finish_ptr_reg;
         op_axil_write_pipe_reg <= op_axil_write_pipe_next;
         op_axil_read_pipe_reg <= op_axil_read_pipe_next;
         op_req_pipe_reg <= op_req_pipe_next;
@@ -647,7 +657,9 @@ always @(posedge clk) begin
         end
         if (op_table_finish_en) begin
             op_table_finish_ptr_reg <= op_table_finish_ptr_reg + 1;
+            op_table_finish_ptr_var = op_table_finish_ptr_reg + 1;
             op_table_active[op_table_finish_ptr_reg] <= 1'b0;
+            op_table_queue_finish_out_reg <= op_table_queue_finish[op_table_finish_ptr_var];
         end
     end
 
@@ -686,10 +698,25 @@ always @(posedge clk) begin
         queue_ram_read_data_pipeline_reg[i] <= queue_ram_read_data_pipeline_reg[i-1];
     end
 
+    if (PIPELINE == 2) begin
+        queue_ram_read_data_op_index_var = queue_ram_read_data_reg[63:56];
+    end else begin
+        queue_ram_read_data_op_index_var = queue_ram_read_data_pipeline_reg[PIPELINE-2][63:56];
+    end
+    op_table_queue_out_reg <= op_table_queue[queue_ram_read_data_op_index_var];
+
     if (op_table_start_en) begin
         op_table_commit[op_table_start_ptr_reg] <= 1'b0;
         op_table_queue[op_table_start_ptr_reg] <= op_table_start_queue;
+        op_table_queue_finish[op_table_start_ptr_reg] <= op_table_start_queue;
         op_table_queue_ptr[op_table_start_ptr_reg] <= op_table_start_queue_ptr;
+        if (op_table_finish_ptr_var == op_table_start_ptr_reg) begin
+            op_table_queue_finish_out_reg <= op_table_start_queue;
+        end
+
+        if (op_table_start_ptr_reg == queue_ram_read_data_op_index_var) begin
+            op_table_queue_out_reg <= op_table_start_queue;
+        end
     end
     if (op_table_commit_en) begin
         op_table_commit[op_table_commit_ptr] <= 1'b1;

--- a/fpga/lib/axi/rtl/axil_crossbar_rd.v
+++ b/fpga/lib/axi/rtl/axil_crossbar_rd.v
@@ -320,6 +320,7 @@ generate
 
         reg [FIFO_ADDR_WIDTH+1-1:0] fifo_wr_ptr_reg = 0;
         reg [FIFO_ADDR_WIDTH+1-1:0] fifo_rd_ptr_reg = 0;
+        wire [FIFO_ADDR_WIDTH+1-1:0] fifo_rd_ptr_inc = fifo_rd_ptr_reg + 1;
 
         (* ram_style = "distributed", ramstyle = "no_rw_check, mlab" *)
         reg [CL_S_COUNT-1:0] fifo_select[(2**FIFO_ADDR_WIDTH)-1:0];
@@ -329,6 +330,7 @@ generate
         reg fifo_half_full_reg = 1'b0;
 
         wire fifo_empty = fifo_rd_ptr_reg == fifo_wr_ptr_reg;
+        reg [CL_S_COUNT-1:0] b_select_reg;
 
         integer i;
 
@@ -338,20 +340,31 @@ generate
             end
         end
 
-        always @(posedge clk) begin
+        always @(posedge clk) begin : fifo_p
+
+            reg [FIFO_ADDR_WIDTH:0] fifo_curr_rd_ptr;
+            fifo_curr_rd_ptr = fifo_rd_ptr_reg;
+
+            if (fifo_rd_en) begin
+                fifo_rd_ptr_reg <= fifo_rd_ptr_reg + 1;
+                b_select_reg <= fifo_select[fifo_rd_ptr_inc[FIFO_ADDR_WIDTH-1:0]];
+                fifo_curr_rd_ptr = fifo_rd_ptr_inc;
+            end
+
             if (fifo_wr_en) begin
                 fifo_select[fifo_wr_ptr_reg[FIFO_ADDR_WIDTH-1:0]] <= fifo_wr_select;
                 fifo_wr_ptr_reg <= fifo_wr_ptr_reg + 1;
-            end
-            if (fifo_rd_en) begin
-                fifo_rd_ptr_reg <= fifo_rd_ptr_reg + 1;
-            end
+                if (fifo_wr_ptr_reg[FIFO_ADDR_WIDTH-1:0] == fifo_curr_rd_ptr[FIFO_ADDR_WIDTH-1:0]) begin
+                    b_select_reg <= fifo_wr_select;
+                end
+	    end
 
             fifo_half_full_reg <= $unsigned(fifo_wr_ptr_reg - fifo_rd_ptr_reg) >= 2**(FIFO_ADDR_WIDTH-1);
 
             if (rst) begin
                 fifo_wr_ptr_reg <= 0;
                 fifo_rd_ptr_reg <= 0;
+                b_select_reg <= 0;
             end
         end
 
@@ -396,7 +409,7 @@ generate
         assign fifo_wr_en = s_axil_arvalid_mux && s_axil_arready_mux && a_grant_valid;
 
         // read response forwarding
-        wire [CL_S_COUNT-1:0] r_select = S_COUNT > 1 ? fifo_select[fifo_rd_ptr_reg[FIFO_ADDR_WIDTH-1:0]] : 0;
+        wire [CL_S_COUNT-1:0] r_select = S_COUNT > 1 ? b_select_reg : 0;
 
         assign int_axil_rvalid[n*S_COUNT +: S_COUNT] = int_m_axil_rvalid[n] << r_select;
         assign int_m_axil_rready[n] = int_axil_rready[r_select*M_COUNT+n];

--- a/fpga/lib/axi/rtl/axil_crossbar_wr.v
+++ b/fpga/lib/axi/rtl/axil_crossbar_wr.v
@@ -180,6 +180,15 @@ generate
 
         reg [CL_M_COUNT-1:0] fifo_rd_select_reg = 0;
         reg fifo_rd_decerr_reg = 0;
+
+        reg [CL_M_COUNT-1:0] fifo_rd_select_int_reg = 0;
+        reg fifo_rd_decerr_int_reg = 0;
+
+        reg  fifo_rd_valid_last_reg = 0;
+
+        reg [CL_M_COUNT-1:0] fifo_rd_select = 0;
+        reg fifo_rd_decerr = 0;
+
         reg fifo_rd_valid_reg = 0;
         wire fifo_rd_en;
         reg fifo_half_full_reg = 1'b0;
@@ -196,6 +205,8 @@ generate
         end
 
         always @(posedge clk) begin
+
+            fifo_rd_valid_last_reg <= 1'b0;
             if (fifo_wr_en) begin
                 fifo_select[fifo_wr_ptr_reg[FIFO_ADDR_WIDTH-1:0]] <= fifo_wr_select;
                 fifo_decerr[fifo_wr_ptr_reg[FIFO_ADDR_WIDTH-1:0]] <= fifo_wr_decerr;
@@ -204,12 +215,17 @@ generate
 
             fifo_rd_valid_reg <= fifo_rd_valid_reg && !fifo_rd_en;
 
+            fifo_rd_select_int_reg <= fifo_select[fifo_rd_ptr_reg[FIFO_ADDR_WIDTH-1:0]];
+            fifo_rd_decerr_int_reg <= fifo_decerr[fifo_rd_ptr_reg[FIFO_ADDR_WIDTH-1:0]];
             if ((fifo_rd_ptr_reg != fifo_wr_ptr_reg) && (!fifo_rd_valid_reg || fifo_rd_en)) begin
-                fifo_rd_select_reg <= fifo_select[fifo_rd_ptr_reg[FIFO_ADDR_WIDTH-1:0]];
-                fifo_rd_decerr_reg <= fifo_decerr[fifo_rd_ptr_reg[FIFO_ADDR_WIDTH-1:0]];
                 fifo_rd_valid_reg <= 1'b1;
                 fifo_rd_ptr_reg <= fifo_rd_ptr_reg + 1;
+                fifo_rd_valid_last_reg <= 1'b1;
             end
+            if (fifo_rd_valid_last_reg == 1'b1) begin
+                fifo_rd_select_reg <= fifo_rd_select_int_reg;
+                fifo_rd_decerr_reg <= fifo_rd_decerr_int_reg;
+           end;
 
             fifo_half_full_reg <= $unsigned(fifo_wr_ptr_reg - fifo_rd_ptr_reg) >= 2**(FIFO_ADDR_WIDTH-1);
 
@@ -219,6 +235,16 @@ generate
                 fifo_rd_valid_reg <= 1'b0;
             end
         end
+
+        always @(*) begin
+            if (fifo_rd_valid_last_reg == 1'b1) begin
+                fifo_rd_select <= fifo_rd_select_int_reg;
+                fifo_rd_decerr <= fifo_rd_decerr_int_reg;
+            end else begin
+                fifo_rd_select <= fifo_rd_select_reg;
+                fifo_rd_decerr <= fifo_rd_decerr_reg;
+            end
+       end
 
         // address decode and admission control
         wire [CL_M_COUNT-1:0] a_select;
@@ -328,8 +354,8 @@ generate
         assign m_rc_ready = !fifo_half_full_reg;
 
         // write response handling
-        wire [CL_M_COUNT-1:0] b_select = M_COUNT > 1 ? fifo_rd_select_reg : 0;
-        wire b_decerr = fifo_rd_decerr_reg;
+        wire [CL_M_COUNT-1:0] b_select = M_COUNT > 1 ? fifo_rd_select : 0;
+        wire b_decerr = fifo_rd_decerr;
         wire b_valid = fifo_rd_valid_reg;
 
         // write response mux

--- a/fpga/lib/axi/rtl/axil_crossbar_wr.v
+++ b/fpga/lib/axi/rtl/axil_crossbar_wr.v
@@ -384,6 +384,7 @@ generate
 
         reg [FIFO_ADDR_WIDTH+1-1:0] fifo_wr_ptr_reg = 0;
         reg [FIFO_ADDR_WIDTH+1-1:0] fifo_rd_ptr_reg = 0;
+        wire [FIFO_ADDR_WIDTH+1-1:0] fifo_rd_ptr_inc = fifo_rd_ptr_reg + 1;
 
         (* ram_style = "distributed", ramstyle = "no_rw_check, mlab" *)
         reg [CL_S_COUNT-1:0] fifo_select[(2**FIFO_ADDR_WIDTH)-1:0];
@@ -393,6 +394,7 @@ generate
         reg fifo_half_full_reg = 1'b0;
 
         wire fifo_empty = fifo_rd_ptr_reg == fifo_wr_ptr_reg;
+        reg [CL_S_COUNT-1:0] b_select_reg;
 
         integer i;
 
@@ -402,13 +404,23 @@ generate
             end
         end
 
-        always @(posedge clk) begin
+        always @(posedge clk) begin : fifo_p
+
+           reg [FIFO_ADDR_WIDTH+1-1:0] fifo_curr_rd_ptr;
+           fifo_curr_rd_ptr = fifo_rd_ptr_reg;
+
+            if (fifo_rd_en) begin
+                fifo_rd_ptr_reg <= fifo_rd_ptr_reg + 1;
+                b_select_reg <= fifo_select[fifo_rd_ptr_inc[FIFO_ADDR_WIDTH-1:0]];
+                fifo_curr_rd_ptr = fifo_rd_ptr_inc;
+            end
+
             if (fifo_wr_en) begin
                 fifo_select[fifo_wr_ptr_reg[FIFO_ADDR_WIDTH-1:0]] <= fifo_wr_select;
                 fifo_wr_ptr_reg <= fifo_wr_ptr_reg + 1;
-            end
-            if (fifo_rd_en) begin
-                fifo_rd_ptr_reg <= fifo_rd_ptr_reg + 1;
+                if (fifo_wr_ptr_reg[FIFO_ADDR_WIDTH-1:0] == fifo_curr_rd_ptr[FIFO_ADDR_WIDTH-1:0]) begin
+                    b_select_reg <= fifo_wr_select;
+                end
             end
 
             fifo_half_full_reg <= $unsigned(fifo_wr_ptr_reg - fifo_rd_ptr_reg) >= 2**(FIFO_ADDR_WIDTH-1);
@@ -416,6 +428,7 @@ generate
             if (rst) begin
                 fifo_wr_ptr_reg <= 0;
                 fifo_rd_ptr_reg <= 0;
+                b_select_reg <= 0;
             end
         end
 
@@ -497,7 +510,7 @@ generate
         end
 
         // write response forwarding
-        wire [CL_S_COUNT-1:0] b_select = S_COUNT > 1 ? fifo_select[fifo_rd_ptr_reg[FIFO_ADDR_WIDTH-1:0]] : 0;
+        wire [CL_S_COUNT-1:0] b_select = S_COUNT > 1 ? b_select_reg: 0;
 
         assign int_axil_bvalid[n*S_COUNT +: S_COUNT] = int_m_axil_bvalid[n] << b_select;
         assign int_m_axil_bready[n] = int_axil_bready[b_select*M_COUNT+n];


### PR DESCRIPTION
This PR proposes an initial patch set to improve utilisation and timing for Intel Stratix 10 devices.

It comprises multiple patches. All patches improve the mapping of RTL structures to MLABs via inference. Most patches reduce the number of paths that fail to meet timing significantly. Some patches require further work as they either introduce new paths that fail to meet timing or the RTL inference is not correctly propagated through all instances for currently unknown reasons (a).

One additional RTL structure used several times in the designs are the psdprams, which cannot be inferred into the intended primitives. This is due to a limitation in the Intel Quartus toolchain (b), which currently cannot infer RAMs described within either generate or RTL loops.

The following patches are provided:

        2x queue manager patches
            RTL: RAM inference fixed
            Timing: fixed
            effects are propagated to all instances
        2x axi cross-bar write patches
            RTL: RAM inference fixed
            Timing: introduce additional failing paths
            changes are not propagated to all instances (instances in mqnic interface #0 pick the changes up, the others not)
        2x axi cross-bar read patches
            RTL: RAM inference fixed
            Timing: introduce additional failing paths
            effects are propagated to all instances
        2x dma ram demux patches
            RTL: RAM inference fixed
            Timing: fixed
            effects are propagated to all instances

We are working closely with Intel to resolve issues like inconsistent inference of RTL structures (a) and to mitigate toolchain limitations preventing proper inference of the psdprams.

To prove we did not unintendedly introduce functional changes, we used formal verification based on yosis to prove that the patches do not introduce changes at the module level boundary. We added the tool set in a separate branch, see https://github.com/missinglinkelectronics/corundum/tree/mle/mlab_fix_formal_verification. The provided scripts rely on the open source tools

        Yosis (v0.13),
        Symbiosis (v20220112-g02a5b71) and
        Yices (2.6.4)

to be installed and available in path.

To make sure that the timing of designs targeting Xilinx devices is not degraded and the RAM is continuously correctly inferred for them as well, the NetFPGA SUME design has been built for reference; it was successfully verified that our patches do not introduce notable timing variation.

We also successfully ran the ZCU106 fpga_core simulation as well as some module-level simulations to make sure we did not break the functionality of the overall design.