### PR TITLE
fix partial initialisation of memory

### DIFF
--- a/fpga/common/rtl/cpl_queue_manager.v
+++ b/fpga/common/rtl/cpl_queue_manager.v
@@ -299,7 +299,7 @@ integer i, j;
 
 initial begin
     // break up loop to work around iteration termination
-    for (i = 0; i < QUEUE_INDEX_WIDTH; i = i + 2**(QUEUE_INDEX_WIDTH/2)) begin
+    for (i = 0; i < 2**QUEUE_INDEX_WIDTH; i = i + 2**(QUEUE_INDEX_WIDTH/2)) begin
         for (j = i; j < i + 2**(QUEUE_INDEX_WIDTH/2); j = j + 1) begin
             queue_ram[j] = 0;
         end

--- a/fpga/common/rtl/queue_manager.v
+++ b/fpga/common/rtl/queue_manager.v
@@ -300,7 +300,7 @@ integer i, j;
 
 initial begin
     // break up loop to work around iteration termination
-    for (i = 0; i < QUEUE_INDEX_WIDTH; i = i + 2**(QUEUE_INDEX_WIDTH/2)) begin
+    for (i = 0; i < 2**QUEUE_INDEX_WIDTH; i = i + 2**(QUEUE_INDEX_WIDTH/2)) begin
         for (j = i; j < i + 2**(QUEUE_INDEX_WIDTH/2); j = j + 1) begin
             queue_ram[j] = 0;
         end

--- a/fpga/common/rtl/tx_scheduler_rr.v
+++ b/fpga/common/rtl/tx_scheduler_rr.v
@@ -389,7 +389,7 @@ integer i, j;
 
 initial begin
     // break up loop to work around iteration termination
-    for (i = 0; i < QUEUE_INDEX_WIDTH; i = i + 2**(QUEUE_INDEX_WIDTH/2)) begin
+    for (i = 0; i < 2**QUEUE_INDEX_WIDTH; i = i + 2**(QUEUE_INDEX_WIDTH/2)) begin
         for (j = i; j < i + 2**(QUEUE_INDEX_WIDTH/2); j = j + 1) begin
             queue_ram[j] = 0;
         end


### PR DESCRIPTION
Unfortunately, a partial initialisation of the memory was introduced when reducing the loop iteration number for intel quartus elaboration, see commit 0560f98e799d741d62522e61bf23321fc3f2880b. This is now fixed.

This lead to an issue discovered in some simulations.