### PR TITLE
Link status monitoring support in mqnic driver

### DIFF
--- a/modules/mqnic/mqnic.h
+++ b/modules/mqnic/mqnic.h
@@ -49,6 +49,7 @@
 #include <linux/etherdevice.h>
 #include <linux/net_tstamp.h>
 #include <linux/ptp_clock_kernel.h>
+#include <linux/timer.h>
 
 #include <linux/i2c.h>
 #include <linux/i2c-algo-bit.h>
@@ -66,9 +67,14 @@
 #define MQNIC_PROP_MODULE_EEPROM "module-eeproms"
 #endif
 
+// default interval to poll port TX/RX status, in ms
+#define MQNIC_LINK_STATUS_POLL_MS 1000
+
 extern unsigned int mqnic_num_ev_queue_entries;
 extern unsigned int mqnic_num_tx_queue_entries;
 extern unsigned int mqnic_num_rx_queue_entries;
+
+extern unsigned int mqnic_link_status_poll;
 
 struct mqnic_dev;
 struct mqnic_if;
@@ -455,6 +461,9 @@ struct mqnic_priv {
 	bool port_up;
 
 	u32 if_features;
+
+	unsigned int link_status;
+	struct timer_list link_status_timer;
 
 	u32 event_queue_count;
 	struct mqnic_eq_ring *event_ring[MQNIC_MAX_EVENT_RINGS];

--- a/modules/mqnic/mqnic_ethtool.c
+++ b/modules/mqnic/mqnic_ethtool.c
@@ -342,6 +342,7 @@ static int mqnic_get_module_eeprom_by_page(struct net_device *ndev,
 
 const struct ethtool_ops mqnic_ethtool_ops = {
 	.get_drvinfo = mqnic_get_drvinfo,
+	.get_link = ethtool_op_get_link,
 	.get_ts_info = mqnic_get_ts_info,
 	.get_module_info = mqnic_get_module_info,
 	.get_module_eeprom = mqnic_get_module_eeprom,

--- a/modules/mqnic/mqnic_main.c
+++ b/modules/mqnic/mqnic_main.c
@@ -462,7 +462,9 @@ fail_create_if:
 	return 0;
 
 	// error handling
+#ifdef CONFIG_AUXILIARY_BUS
 fail_adev:
+#endif
 fail_miscdev:
 fail_board:
 fail_bar_size:

--- a/modules/mqnic/mqnic_main.c
+++ b/modules/mqnic/mqnic_main.c
@@ -59,6 +59,13 @@ MODULE_PARM_DESC(num_tx_queue_entries, "number of entries to allocate per transm
 module_param_named(num_rx_queue_entries, mqnic_num_rx_queue_entries, uint, 0444);
 MODULE_PARM_DESC(num_rx_queue_entries, "number of entries to allocate per receive queue (default: 1024)");
 
+unsigned int mqnic_link_status_poll = MQNIC_LINK_STATUS_POLL_MS;
+
+module_param_named(link_status_poll, mqnic_link_status_poll, uint, 0444);
+MODULE_PARM_DESC(link_status_poll,
+		 "link status polling interval, in ms (default: 1000; 0 to turn off)");
+
+
 #ifdef CONFIG_PCI
 static const struct pci_device_id mqnic_pci_id_table[] = {
 	{PCI_DEVICE(0x1234, 0x1001)},


### PR DESCRIPTION
Hi Alex,

as briefly discussed via Slack, here is our PR regarding link status monitoring in the mqnic driver. Plus 1 related commit (`ethtool`) and 1 unrelated minor fix (AuxBus).

The logic around when a netdev is considered to have a "carrier on" state might need more discussion. At least to me it makes sense to assume, by default and/or just for now, that an mqnic-interface (== Linux netdev) is safe to be considered "up", when all mqnic-ports are up - without further knowledge.