### PR TITLE
fix sfp eeprom readout

### DIFF
--- a/modules/mqnic/mqnic_ethtool.c
+++ b/modules/mqnic/mqnic_ethtool.c
@@ -141,20 +141,21 @@ static int mqnic_query_module_eeprom_by_page(struct net_device *ndev,
 	case SFF_MODULE_ID_SFP:
 		if (page > 0 || bank > 0)
 			return -EINVAL;
+		if (i2c_addr != 0x50 && i2c_addr != 0x51)
+			return -EINVAL;
 		break;
 	case SFF_MODULE_ID_QSFP:
 	case SFF_MODULE_ID_QSFP_PLUS:
 	case SFF_MODULE_ID_QSFP28:
 		if (page > 3 || bank > 0)
 			return -EINVAL;
+		if (i2c_addr != 0x50)
+			return -EINVAL;
 		break;
 	default:
 		dev_err(priv->dev, "%s: Unknown module ID (0x%x)", __func__, module_id);
 		return -EINVAL;
 	}
-
-	if (i2c_addr != 0x50)
-		return -EINVAL;
 
 	// set page
 	switch (module_id) {
@@ -199,7 +200,7 @@ static int mqnic_query_module_eeprom(struct net_device *ndev,
 	case SFF_MODULE_ID_SFP:
 		i2c_addr = 0x50;
 		page = 0;
-		if (offset > 256) {
+		if (offset >= 256) {
 			offset -= 256;
 			i2c_addr = 0x51;
 		}

--- a/modules/mqnic/mqnic_ethtool.c
+++ b/modules/mqnic/mqnic_ethtool.c
@@ -129,6 +129,8 @@ static int mqnic_query_module_eeprom_by_page(struct net_device *ndev,
 	struct mqnic_priv *priv = netdev_priv(ndev);
 	int module_id;
 	u8 d;
+	int ret;
+	unsigned short orig_i2c_addr;
 
 	module_id = mqnic_query_module_id(ndev);
 
@@ -176,8 +178,23 @@ static int mqnic_query_module_eeprom_by_page(struct net_device *ndev,
 		return -EINVAL;
 	}
 
+	// set i2c address of the mod_i2c_client
+	// This code section should not be called concurrently since the IOCTL
+	// handler for ethtool operations is called under the RTNL lock.
+	// In addition the i2c_client is used only within code inside this lock.
+	if (!priv->mod_i2c_client)
+		return -EINVAL;
+
+	orig_i2c_addr = priv->mod_i2c_client->addr;
+	priv->mod_i2c_client->addr = i2c_addr;
+
 	// read data
-	return mqnic_read_module_eeprom(ndev, offset, len, data);
+	ret = mqnic_read_module_eeprom(ndev, offset, len, data);
+
+	// reset i2c addr
+	priv->mod_i2c_client->addr = orig_i2c_addr;
+
+	return ret;
 }
 
 static int mqnic_query_module_eeprom(struct net_device *ndev,

--- a/modules/mqnic/mqnic_ethtool.c
+++ b/modules/mqnic/mqnic_ethtool.c
@@ -124,7 +124,7 @@ static int mqnic_query_module_id(struct net_device *ndev)
 }
 
 static int mqnic_query_module_eeprom_by_page(struct net_device *ndev,
-		u8 i2c_addr, u16 page, u16 bank, u16 offset, u16 len, u8 *data)
+		unsigned short i2c_addr, u16 page, u16 bank, u16 offset, u16 len, u8 *data)
 {
 	struct mqnic_priv *priv = netdev_priv(ndev);
 	int module_id;
@@ -202,7 +202,7 @@ static int mqnic_query_module_eeprom(struct net_device *ndev,
 {
 	struct mqnic_priv *priv = netdev_priv(ndev);
 	int module_id;
-	u8 i2c_addr = 0x50;
+	unsigned short i2c_addr = 0x50;
 	u16 page = 0;
 	u16 bank = 0;
 


### PR DESCRIPTION
This PR fixes issue #111 that is about missing support of SFP module diagnostics read-out.

We should have a chat about the topic if changing the I2C address of the i2c_client object requires the need to add a lock around using this client. It could potentially happen that in concurrent use cases the address, e.g. for a module_info inquiry, is not the one as expected, e.g. 0x51 instead of 0x50.