### PR TITLE
Fix petalinux build issues seen for the ZCU106

### DIFF
--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -74,7 +74,7 @@ Running tests
 
 Once the packages are installed, you should be able to run the tests.  There are several ways to do this.
 
-First, all tests can be run by runing ``tox`` in the repo root.  In this case, tox will set up a python virtual environment and install all python dependencies inside the virtual environment.  Additionally, tox will run pytest as ``pytest -n auto`` so it will run tests in parallel on multiple CPUs. ::
+First, all tests can be run by running ``tox`` in the repo root.  In this case, tox will set up a python virtual environment and install all python dependencies inside the virtual environment.  Additionally, tox will run pytest as ``pytest -n auto`` so it will run tests in parallel on multiple CPUs. ::
 
     $ cd /path/to/corundum/
     $ tox
@@ -218,7 +218,7 @@ For example: if you want to build a 100G design for an Alveo U50, you will not n
 
 Before building a design with Vivado, you'll have to source the appropriate settings file.  For example::
 
-    $ source /opt/Xilinx/Vivado/2020.2/settings64.sh
+    $ source /opt/Xilinx/Vivado/2021.1/settings64.sh
     $ make
 
 Building the FPGA configuration
@@ -229,7 +229,7 @@ Each design contains a set of makefiles for automating the build process.  To us
 For example::
 
     $ cd /path/to/corundum/fpga/mqnic/[board]/fpga_[variant]/fpga
-    $ source /opt/Xilinx/Vivado/2020.2/settings64.sh
+    $ source /opt/Xilinx/Vivado/2021.1/settings64.sh
     $ make
 
 Building the driver
@@ -551,7 +551,7 @@ Finally, test the PTP synchronization performance with ``ptp4l`` from ``linuxptp
 
 On the server::
 
-    $ sudo ptp4l -i enp193s0np0 --masterOnly=1 -m --logSyncInterval=-3
+    $ sudo ptp4l -i enp193s0np0 --masterOnly=1 -m --logSyncInterval=-3 --tx_timestamp_timeout=10
     ptp4l[4463.798]: selected /dev/ptp2 as PTP clock
     ptp4l[4463.799]: port 1: INITIALIZING to LISTENING on INIT_COMPLETE
     ptp4l[4463.799]: port 0: INITIALIZING to LISTENING on INIT_COMPLETE
@@ -561,7 +561,7 @@ On the server::
 
 On the client::
 
-    $ sudo ptp4l -i enp129s0 --slaveOnly=1 -m
+    $ sudo ptp4l -i enp129s0 --slaveOnly=1 -m --tx_timestamp_timeout=10
     ptp4l[642.961]: selected /dev/ptp5 as PTP clock
     ptp4l[642.962]: port 1: INITIALIZING to LISTENING on INIT_COMPLETE
     ptp4l[642.962]: port 0: INITIALIZING to LISTENING on INIT_COMPLETE

--- a/fpga/lib/psmake/petalinux.mk
+++ b/fpga/lib/psmake/petalinux.mk
@@ -206,6 +206,11 @@ $(PRJ_HDF): $(HDF) $(subst gethdf,FORCE,$(findstring gethdf,$(MAKECMDGOALS)))
 	mkdir -p $(dir $(TMPHDF))
 	ln -sf $(realpath $(HDF)) $(TMPHDF)
 	petalinux-config $(GEN_ARGS) --get-hw-description $(dir $(TMPHDF)) $(SILENTCONFIG)
+	# Linuxptp patch fix for issue here: 
+	# https://support.xilinx.com/s/question/0D52E00006ihQMPSA2/issues-adding-linuxptp-package-in-petalinux-20211?language=en_US
+	rm -f components/yocto/layers/meta-openembedded/meta-oe/recipes-connectivity/linuxptp/linuxptp_3.1.bb
+	cp ../../patches/linuxptp_3.1.1.bb components/yocto/layers/meta-openembedded/meta-oe/recipes-connectivity/linuxptp/
+
 
 gethdf: $(PRJ_HDF)
 

--- a/fpga/mqnic/ZCU106/fpga_zynqmp/patches/linuxptp_3.1.1.bb
+++ b/fpga/mqnic/ZCU106/fpga_zynqmp/patches/linuxptp_3.1.1.bb
@@ -1,0 +1,23 @@
+DESCRIPTION = "Precision Time Protocol (PTP) according to IEEE standard 1588 for Linux"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+SRC_URI = "http://sourceforge.net/projects/linuxptp/files/v3.1/linuxptp-3.1.1.tgz \
+           file://build-Allow-CC-and-prefix-to-be-overriden.patch \
+           file://Use-cross-cpp-in-incdefs.patch \
+           "
+
+SRC_URI[md5sum] = "3b79ab5e77c5b5cf06bc1c8350d405bb"
+SRC_URI[sha256sum] = "94d6855f9b7f2d8e9b0ca6d384e3fae6226ce6fc012dbad02608bdef3be1c0d9"
+
+EXTRA_OEMAKE = "ARCH=${TARGET_ARCH} EXTRA_CFLAGS='${CFLAGS}'"
+
+export KBUILD_OUTPUT="${RECIPE_SYSROOT}"
+
+do_install () {
+    install -d ${D}/${bindir}
+    install -p ${S}/ptp4l  ${D}/${bindir}
+    install -p ${S}/pmc  ${D}/${bindir}
+    install -p ${S}/phc2sys  ${D}/${bindir}
+    install -p ${S}/hwstamp_ctl  ${D}/${bindir}
+}

--- a/fpga/mqnic/ZCU106/fpga_zynqmp/ps/petalinux/project-spec/configs/config
+++ b/fpga/mqnic/ZCU106/fpga_zynqmp/ps/petalinux/project-spec/configs/config
@@ -290,7 +290,7 @@ CONFIG_YOCTO_NETWORK_SSTATE_FEEDS=y
 #
 # Network sstate feeds URL
 #
-CONFIG_YOCTO_NETWORK_SSTATE_FEEDS_URL="http://petalinux.xilinx.com/sswreleases/rel-v${PETALINUX_VER%%.*}/aarch64/sstate-cache"
+CONFIG_YOCTO_NETWORK_SSTATE_FEEDS_URL="http://petalinux.xilinx.com/sswreleases/rel-v2021.1/aarch64/sstate-cache"
 # CONFIG_YOCTO_BB_NO_NETWORK is not set
 # CONFIG_YOCTO_BUILDTOOLS_EXTENDED is not set
 

--- a/fpga/mqnic/ZCU106/fpga_zynqmp/ps/petalinux/project-spec/meta-user/recipes-bsp/fsbl-firmware/fsbl-firmware_%.bbappend
+++ b/fpga/mqnic/ZCU106/fpga_zynqmp/ps/petalinux/project-spec/meta-user/recipes-bsp/fsbl-firmware/fsbl-firmware_%.bbappend
@@ -1,4 +1,4 @@
 ###############################################################################
 # enable message level FSBL_DEBUG_DETAILED
 
-YAML_COMPILER_FLAGS_append = " -DFSBL_DEBUG_DETAILED"
+#YAML_COMPILER_FLAGS_append = " -DFSBL_DEBUG_DETAILED"


### PR DESCRIPTION
########################
ZCU106 FIX DOCUMENTATION
########################

DIFFs:

#. ``project-spec/configs/config`` - Contains the new NETWORK STATE FEEDS URL Bug Fix 

   ::  

      -CONFIG_YOCTO_NETWORK_SSTATE_FEEDS_URL="http://petalinux.xilinx.com/sswreleases/rel-v${PETALINUX_VER%%.*}/aarch64/sstate-cache"
      +CONFIG_YOCTO_NETWORK_SSTATE_FEEDS_URL="http://petalinux.xilinx.com/sswreleases/rel-v2021.1/aarch64/sstate-cache"

   ..  

   - `Link to NETWORK SSTATE Bug-Fix <https://support.xilinx.com/s/article/76598?language=en_US>`_

#. ``project-spec/meta-user/recipes-bsp/fsbl-firmware/fsbl-firmware_%.bbappend`` - Contains a fix for FSBL size optimization / .dup_date / AXI_BASEADDR errors. Commented the following line:

   ::  

      YAML_COMPILER_FLAGS_append = " -DFSBL_DEBUG_DETAILED

   ..  

   - `Link to DFSBL_DEBUG_DETAILED Bug-fix <https://support.xilinx.com/s/question/0D52E00006hpmsqSAA/zynqmp-fsbl-build-failure-with-fsbldebuginfo?language=en_US>`_

#. The new Petalinux project also contains a fix for the linuxptp fetching issue and dependencies. When building the original petalinux project, the project does not correctly fetch and build the linuxptp portion of the project. Link below:

 - `Link: <https://support.xilinx.com/s/question/0D52E00006ihQMPSA2/issues-adding-linuxptp-package-in-petalinux-20211?language=en_US>`_

 #. The following is now all captured in the edits made to the ps/petalinux/Makefile here:

   ::  

      # force only if "gethdf" is one of the targets
      $(PRJ_HDF): $(HDF) $(subst gethdf,FORCE,$(findstring gethdf,$(MAKECMDGOALS)))
      mkdir -p $(dir $(TMPHDF))
      ln -sf $(realpath $(HDF)) $(TMPHDF)
      petalinux-config $(GEN_ARGS) --get-hw-description $(dir $(TMPHDF)) $(SILENTCONFIG)
      # Linuxptp patch fix for issue here: 
      # https://support.xilinx.com/s/question/0D52E00006ihQMPSA2/issues-adding-linuxptp-package-in-petalinux-20211?language=en_US
      rm -f components/yocto/layers/meta-openembedded/meta-oe/recipes-connectivity/linuxptp/linuxptp_3.1.bb
      cp ../../patches/linuxptp_3.1.1.bb components/yocto/layers/meta-openembedded/meta-oe/recipes-connectivity/linuxptp/

   ..  

#. The following linuxptp_3.1.1.bb is stored in the fpga_zynq/patches file

#. ``cd <pl_proj>/components/yocto/layers/meta-openembedded/meta-oe/recipes-connectivity/linunxptp``

#. ``mv linuxptp_3.1.bb linuxptp_3.1.1.bb``

#. Edit linuxptp_3.1.1.bb to the following:

   ::  

      DESCRIPTION = "Precision Time Protocol (PTP) according to IEEE standard 1588 for Linux"
      LICENSE = "GPLv2"
      LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"

      SRC_URI = "http://sourceforge.net/projects/linuxptp/files/v3.1/linuxptp-3.1.1.tgz \
                 file://build-Allow-CC-and-prefix-to-be-overriden.patch \
                 file://Use-cross-cpp-in-incdefs.patch \
                 "

      SRC_URI[md5sum] = "3b79ab5e77c5b5cf06bc1c8350d405bb"
      SRC_URI[sha256sum] = "94d6855f9b7f2d8e9b0ca6d384e3fae6226ce6fc012dbad02608bdef3be1c0d9"

      EXTRA_OEMAKE = "ARCH=${TARGET_ARCH} EXTRA_CFLAGS='${CFLAGS}'"

      export KBUILD_OUTPUT="${RECIPE_SYSROOT}"

      do_install () {
          install -d ${D}/${bindir}
          install -p ${S}/ptp4l  ${D}/${bindir}
          install -p ${S}/pmc  ${D}/${bindir}
          install -p ${S}/phc2sys  ${D}/${bindir}
          install -p ${S}/hwstamp_ctl  ${D}/${bindir}
      }

   ..
