### PR TITLE
Export existing dropped_packets counter per TX ring to netdev statistics; ignore/clean additions

### DIFF
--- a/lib/mqnic/.gitignore
+++ b/lib/mqnic/.gitignore
@@ -1,0 +1,1 @@
+libmqnic.a

--- a/modules/mqnic/mqnic_netdev.c
+++ b/modules/mqnic/mqnic_netdev.c
@@ -230,6 +230,7 @@ void mqnic_update_stats(struct net_device *ndev)
 {
 	struct mqnic_priv *priv = netdev_priv(ndev);
 	unsigned long packets, bytes;
+	unsigned long dropped;
 	int k;
 
 	if (unlikely(!priv->port_up))
@@ -237,25 +238,31 @@ void mqnic_update_stats(struct net_device *ndev)
 
 	packets = 0;
 	bytes = 0;
+	dropped = 0;
 	for (k = 0; k < priv->rx_queue_count; k++) {
 		const struct mqnic_ring *ring = priv->rx_ring[k];
 
 		packets += READ_ONCE(ring->packets);
 		bytes += READ_ONCE(ring->bytes);
+		dropped += READ_ONCE(ring->dropped_packets);
 	}
 	ndev->stats.rx_packets = packets;
 	ndev->stats.rx_bytes = bytes;
+	ndev->stats.rx_dropped = dropped;
 
 	packets = 0;
 	bytes = 0;
+	dropped = 0;
 	for (k = 0; k < priv->tx_queue_count; k++) {
 		const struct mqnic_ring *ring = priv->tx_ring[k];
 
 		packets += READ_ONCE(ring->packets);
 		bytes += READ_ONCE(ring->bytes);
+		dropped += READ_ONCE(ring->dropped_packets);
 	}
 	ndev->stats.tx_packets = packets;
 	ndev->stats.tx_bytes = bytes;
+	ndev->stats.tx_dropped = dropped;
 }
 
 static void mqnic_get_stats64(struct net_device *ndev,

--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -2,4 +2,5 @@ mqnic-config
 mqnic-bmc
 mqnic-dump
 mqnic-fw
+mqnic-xcvr
 perout

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -59,6 +59,7 @@ clean:
 	rm -f $(BIN)
 	rm -f *.o
 	rm -f .*.d
+	$(MAKE) -C $(dir $(LIBMQNIC))/ $@
 
 -include $(wildcard .*.d)
 


### PR DESCRIPTION
Hi Alex,

this pull request comprises a few minimal/minor older patches, which might make sense to be included in the official repository.

In this small number of patches, we introduce

* utils/, lib/ ignore file extensions; cleaning up lib/mqnic
* propagate TX ring dropped packets counter to netdev statistics