### PR TITLE
Handle RX buffer allocation failure; TX queue full as debug message

### DIFF
--- a/modules/mqnic/Makefile
+++ b/modules/mqnic/Makefile
@@ -26,6 +26,10 @@ mqnic-y += mqnic_cq.o
 mqnic-y += mqnic_eq.o
 mqnic-y += mqnic_ethtool.o
 
+ifneq ($(DEBUG),)
+ccflags-y += -DDEBUG
+endif
+
 else
 
 ifneq ($(KERNEL_SRC),)

--- a/modules/mqnic/mqnic.h
+++ b/modules/mqnic/mqnic.h
@@ -624,7 +624,7 @@ void mqnic_rx_write_head_ptr(struct mqnic_ring *ring);
 void mqnic_free_rx_desc(struct mqnic_ring *ring, int index);
 int mqnic_free_rx_buf(struct mqnic_ring *ring);
 int mqnic_prepare_rx_desc(struct mqnic_ring *ring, int index);
-void mqnic_refill_rx_buffers(struct mqnic_ring *ring);
+int mqnic_refill_rx_buffers(struct mqnic_ring *ring);
 int mqnic_process_rx_cq(struct mqnic_cq *cq, int napi_budget);
 void mqnic_rx_irq(struct mqnic_cq *cq);
 int mqnic_poll_rx_cq(struct napi_struct *napi, int budget);

--- a/modules/mqnic/mqnic_tx.c
+++ b/modules/mqnic/mqnic_tx.c
@@ -484,7 +484,7 @@ netdev_tx_t mqnic_start_xmit(struct sk_buff *skb, struct net_device *ndev)
 
 	stop_queue = mqnic_is_tx_ring_full(ring);
 	if (unlikely(stop_queue)) {
-		netdev_info(ndev, "%s: TX ring %d full on port %d",
+		netdev_dbg(ndev, "%s: TX ring %d full on port %d",
 				__func__, ring_index, priv->index);
 		netif_tx_stop_queue(ring->tx_queue);
 	}


### PR DESCRIPTION
Hi Alex,

NOTE: As [discussed](https://github.com/alexforencich/corundum/pull/2#issuecomment-1608933012), this is a pull request is a replacement for this [pull request](https://github.com/alexforencich/corundum/pull/2), which was against your "bleeding" edge repository.

In this pull request with a small number of patches, we introduce

- the possibility to let RX buffer allocation fail and output a hint for the user on how to proceed
- turning the "TX ring full" message into a debug message, which can be made visible on-demand (given dynamic debug support in the kernel)