### PR TITLE
KR260 fan control

### DIFF
--- a/fpga/mqnic/KR260/fpga/fpga.xdc
+++ b/fpga/mqnic/KR260/fpga/fpga.xdc
@@ -15,7 +15,7 @@ set_false_path -to [get_ports {led[*] sfp_led[*]}]
 set_output_delay 0 [get_ports {led[*] sfp_led[*]}]
 
 # Fan control
-set_property -dict {LOC A12 } [get_ports fan_control] ;# HDA20 som240_1_c24
+set_property -dict {LOC A12  IOSTANDARD LVCMOS33} [get_ports fan_control] ;# HDA20 som240_1_c24
 
 # SFP+ Interface
 set_property -dict {LOC T2  } [get_ports sfp_rx_p] ;# MGTHRXP2_224 GTHE4_CHANNEL_X1Y12 / GTHE4_COMMON_X1Y3

--- a/fpga/mqnic/KR260/fpga/fpga.xdc
+++ b/fpga/mqnic/KR260/fpga/fpga.xdc
@@ -14,6 +14,9 @@ set_property -dict {LOC F7   IOSTANDARD LVCMOS18 SLEW SLOW DRIVE 8} [get_ports {
 set_false_path -to [get_ports {led[*] sfp_led[*]}]
 set_output_delay 0 [get_ports {led[*] sfp_led[*]}]
 
+# Fan control
+set_property -dict {LOC A12 } [get_ports fan_control] ;# HDA20 som240_1_c24
+
 # SFP+ Interface
 set_property -dict {LOC T2  } [get_ports sfp_rx_p] ;# MGTHRXP2_224 GTHE4_CHANNEL_X1Y12 / GTHE4_COMMON_X1Y3
 set_property -dict {LOC T1  } [get_ports sfp_rx_n] ;# MGTHRXN2_224 GTHE4_CHANNEL_X1Y12 / GTHE4_COMMON_X1Y3

--- a/fpga/mqnic/KR260/fpga/ip/zynq_ps.tcl
+++ b/fpga/mqnic/KR260/fpga/ip/zynq_ps.tcl
@@ -119,6 +119,8 @@ set_property -dict [list \
     CONFIG.PSU__SWDT0__PERIPHERAL__ENABLE {1} \
     CONFIG.PSU__SWDT1__PERIPHERAL__ENABLE {1} \
     CONFIG.PSU__TTC0__PERIPHERAL__ENABLE {1} \
+    CONFIG.PSU__TTC0__WAVEOUT__ENABLE {1} \
+    CONFIG.PSU__TTC0__WAVEOUT__IO {EMIO} \
     CONFIG.PSU__IOU_SLCR__IOU_TTC_APB_CLK__TTC0_SEL {APB} \
     CONFIG.PSU__TTC1__PERIPHERAL__ENABLE {1} \
     CONFIG.PSU__IOU_SLCR__IOU_TTC_APB_CLK__TTC1_SEL {APB} \
@@ -232,6 +234,14 @@ set axi_interconnect_ctrl [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_inte
 # reset
 set proc_sys_reset [ create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset proc_sys_reset ]
 
+# fan control
+set fan_control_slice [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlslice fan_control_slice ]
+set_property -dict [list \
+  CONFIG.DIN_FROM {2} \
+  CONFIG.DIN_TO {2} \
+  CONFIG.DIN_WIDTH {3} \
+] $fan_control_slice
+
 # Create connections
 
 # Clock
@@ -306,6 +316,12 @@ set pl_ps_irq0_port [get_bd_ports -of_objects [get_bd_nets -of_objects $pl_ps_ir
 set_property -dict [list \
     CONFIG.PortWidth 8 \
 ] $pl_ps_irq0_port
+
+# Fan control
+connect_bd_net [get_bd_pins $zynq_ultra_ps/emio_ttc0_wave_o] [get_bd_pins $fan_control_slice/Din]
+set fan_control_pin [get_bd_pins $fan_control_slice/Dout]
+make_bd_pins_external $fan_control_pin
+set_property name fan_control [get_bd_ports -of_objects [get_bd_nets -of_objects $fan_control_pin]]
 
 # Port clock associations
 set lst [list]

--- a/fpga/mqnic/KR260/fpga/rtl/fpga.v
+++ b/fpga/mqnic/KR260/fpga/rtl/fpga.v
@@ -153,6 +153,11 @@ module fpga #
     output wire [1:0]   sfp_led,
 
     /*
+     * Fan control
+     */
+    output wire fan_control,
+
+    /*
      * Ethernet: SFP+
      */
     input  wire         sfp_rx_p,
@@ -420,6 +425,8 @@ zynq_ps zynq_ps_inst (
     .pl_clk0(zynq_pl_clk),
     .pl_reset(zynq_pl_reset),
     .pl_ps_irq0(zynq_irq),
+
+    .fan_control(fan_control),
 
     .m_axil_ctrl_araddr(axil_ctrl_araddr),
     .m_axil_ctrl_arprot(axil_ctrl_arprot),


### PR DESCRIPTION
Hello.

Kria KR260 board has a fan cooling system, and it needs a connection from a PS port to a PL pin.
Since the current design of corundum doesn't have it, the fan is always full-speed and noisy.

I have made some updates on files to fix the problem and checked it seemed to be correctly working.

Reference:
- [Fan Control | Kria SOMs & Starter Kits](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/1641152513/Kria+SOMs+Starter+Kits#Fan-Control)

Thank you.