### PR TITLE
mqnic: no pci build

### DIFF
--- a/modules/mqnic/mqnic_irq.c
+++ b/modules/mqnic/mqnic_irq.c
@@ -14,6 +14,7 @@ static irqreturn_t mqnic_irq_handler(int irqn, void *data)
 	return IRQ_HANDLED;
 }
 
+#ifdef CONFIG_PCI
 int mqnic_irq_init_pcie(struct mqnic_dev *mdev)
 {
 	struct pci_dev *pdev = mdev->pdev;
@@ -77,7 +78,7 @@ void mqnic_irq_deinit_pcie(struct mqnic_dev *mdev)
 
 	pci_free_irq_vectors(pdev);
 }
-
+#endif /* CONFIG_PCI */
 int mqnic_irq_init_platform(struct mqnic_dev *mdev)
 {
 	struct platform_device *pdev = mdev->pfdev;


### PR DESCRIPTION
Fix issue with incorrect pci_irq function masking for systems with mqnic-to-ps connection.

It'll raise an error in case build without CONFIG_PCI=y.