### PR TITLE
fix: increase hardware MTU size due to cut frames in case of vlan tagging

### DIFF
--- a/modules/mqnic/mqnic.h
+++ b/modules/mqnic/mqnic.h
@@ -21,6 +21,7 @@
 #include <linux/ptp_clock_kernel.h>
 #include <linux/timer.h>
 #include <net/devlink.h>
+#include <linux/if_vlan.h>
 
 #include <linux/i2c.h>
 #include <linux/i2c-algo-bit.h>

--- a/modules/mqnic/mqnic_netdev.c
+++ b/modules/mqnic/mqnic_netdev.c
@@ -134,8 +134,8 @@ int mqnic_start_port(struct net_device *ndev)
 	}
 
 	// set MTU
-	mqnic_interface_set_tx_mtu(iface, ndev->mtu + ETH_HLEN);
-	mqnic_interface_set_rx_mtu(iface, ndev->mtu + ETH_HLEN);
+	mqnic_interface_set_tx_mtu(iface, ndev->mtu + ETH_HLEN + VLAN_HLEN);
+	mqnic_interface_set_rx_mtu(iface, ndev->mtu + ETH_HLEN + VLAN_HLEN);
 
 	// configure RX indirection and RSS
 	mqnic_update_indir_table(ndev);


### PR DESCRIPTION
Fix issue #210. Not sure that you'll accept it, but I'd like to keep it for the record. And if you have any comments about the PR - will be happy to fix it.