### PR TITLE
fix possible bug with parallel build utils

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -50,7 +50,7 @@ mqnic-bmc: mqnic-bmc.o $(LIBMQNIC)
 mqnic-xcvr: mqnic-xcvr.o $(LIBMQNIC) drp.o xcvr_gt.o xcvr_gthe3.o xcvr_gtye3.o xcvr_gthe4.o xcvr_gtye4.o
 	$(CC) $(ALL_CFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
-perout: perout.o timespec.o
+perout: perout.o timespec.o $(LIBMQNIC)
 	$(CC) $(ALL_CFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
 
 install:


### PR DESCRIPTION
Fix possible races in case of parallel build. Some times `perout` target runs before `libmqnic` target, but depends on it. Example:

<details>
  <summary>Error build log</summary>

  ```bash
 $ make -j 8                                                                                                                                                                                                             
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .mqnic-config.o.d -c -o mqnic-config.o mqnic-config.c                                                                                                                                                                                 
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .timespec.o.d -c -o timespec.o timespec.c                                                                                                                                                                                             
make -C lib/mqnic/ libmqnic.a                                                                                                                                                                                                                                                  
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .mqnic-dump.o.d -c -o mqnic-dump.o mqnic-dump.c                                                                                                                                                                                       
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .mqnic-fw.o.d -c -o mqnic-fw.o mqnic-fw.c                                                                                                                                                                                             
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .flash.o.d -c -o flash.o flash.c                                                                                                                                                                                                      
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .flash_spi.o.d -c -o flash_spi.o flash_spi.c                                                                                                                                                                                          
make[1]: Entering directory '/home/vlad/Projects/PERSONAL/corundum/lib/mqnic'                                                                                                                                                                                                  
cc -O3 -fPIC -Wall  -MD -MP -MF .mqnic.o.d -c -o mqnic.o mqnic.c                                                                                                                                                                                                               
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .flash_bpi.o.d -c -o flash_bpi.o flash_bpi.c                                                                                                                                                                                          
mqnic-fw.c: In function ‘pcie_hot_reset’:                                                                                                                                                                                                                                      
mqnic-fw.c:440:5: warning: ignoring return value of ‘pread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]                                                                                                                                                     
  440 |     pread(fd, buf, 2, PCI_BRIDGE_CONTROL);                                                                                                                                                                                                                             
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                              
mqnic-fw.c:445:5: warning: ignoring return value of ‘pwrite’ declared with attribute ‘warn_unused_result’ [-Wunused-result]                                                                                                                                                    
  445 |     pwrite(fd, buf+2, 2, PCI_BRIDGE_CONTROL);                                                                                                                                                                                                                          
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                           
mqnic-fw.c:449:5: warning: ignoring return value of ‘pwrite’ declared with attribute ‘warn_unused_result’ [-Wunused-result]                                                                                                                                                    
  449 |     pwrite(fd, buf, 2, PCI_BRIDGE_CONTROL);                                                                                                                                                                                                                            
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                             
mqnic-fw.c: In function ‘pcie_disable_fatal_err’:                                                                                                                                                                                                                              
mqnic-fw.c:474:5: warning: ignoring return value of ‘pread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]                                                                                                                                                     
  474 |     pread(fd, buf, 2, PCI_COMMAND);                                                                                                                                                                                                                                    
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                                     
mqnic-fw.c:478:5: warning: ignoring return value of ‘pwrite’ declared with attribute ‘warn_unused_result’ [-Wunused-result]                                                                                                                                                    
  478 |     pwrite(fd, buf, 2, PCI_COMMAND);                                                                                                                                                                                                                                   
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                                    
mqnic-fw.c:484:5: warning: ignoring return value of ‘pread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]                                                                                                                                                     
  484 |     pread(fd, buf, 1, PCI_CAPABILITY_LIST);                                                                                                                                                                                                                            
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                             
mqnic-fw.c:490:9: warning: ignoring return value of ‘pread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]                                                                                                                                                     
  490 |         pread(fd, buf, 2, offset);                                                                                                                                                                                                                                     
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                                      
mqnic-fw.c:501:9: warning: ignoring return value of ‘pread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]                                                                                                                                                     
  501 |         pread(fd, buf, 2, offset+PCI_EXP_DEVCTL);                                                                                                                                                                                                                      
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                       
mqnic-fw.c:505:9: warning: ignoring return value of ‘pwrite’ declared with attribute ‘warn_unused_result’ [-Wunused-result]                                                                                                                                                    
  505 |         pwrite(fd, buf, 2, offset+PCI_EXP_DEVCTL);                                                                                                                                                                                                                     
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                      
mqnic-fw.c: In function ‘main’:                                                                                                                                                                                                                                                
mqnic-fw.c:909:13: warning: ignoring return value of ‘fgets’ declared with attribute ‘warn_unused_result’ [-Wunused-result]                                                                                                                                                    
  909 |             fgets(str, sizeof(str), stdin);                                                                                                                                                                                                                            
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                             
mqnic-fw.c:1163:17: warning: ignoring return value of ‘fgets’ declared with attribute ‘warn_unused_result’ [-Wunused-result]           
 1163 |                 fgets(str, sizeof(str), stdin);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mqnic-fw.c:1235:17: warning: ignoring return value of ‘fgets’ declared with attribute ‘warn_unused_result’ [-Wunused-result]           
 1235 |                 fgets(str, sizeof(str), stdin);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mqnic-fw.c:1383:13: warning: ignoring return value of ‘fgets’ declared with attribute ‘warn_unused_result’ [-Wunused-result]           
 1383 |             fgets(str, sizeof(str), stdin);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .bitfile.o.d -c -o bitfile.o bitfile.c                                                        
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .mqnic-bmc.o.d -c -o mqnic-bmc.o mqnic-bmc.c                                                  
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .mqnic-xcvr.o.d -c -o mqnic-xcvr.o mqnic-xcvr.c                                               
cc -O3 -fPIC -Wall  -MD -MP -MF .mqnic_res.o.d -c -o mqnic_res.o mqnic_res.c                                                           
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .drp.o.d -c -o drp.o drp.c                                                                    
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .xcvr_gt.o.d -c -o xcvr_gt.o xcvr_gt.c                                                        
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .xcvr_gthe3.o.d -c -o xcvr_gthe3.o xcvr_gthe3.c                                               
cc -O3 -fPIC -Wall  -MD -MP -MF .mqnic_if.o.d -c -o mqnic_if.o mqnic_if.c                                                              
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .xcvr_gtye3.o.d -c -o xcvr_gtye3.o xcvr_gtye3.c                                               
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .xcvr_gthe4.o.d -c -o xcvr_gthe4.o xcvr_gthe4.c 
cc -O3 -fPIC -Wall  -MD -MP -MF .mqnic_port.o.d -c -o mqnic_port.o mqnic_port.c                                                        
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .xcvr_gtye4.o.d -c -o xcvr_gtye4.o xcvr_gtye4.c                                               
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .perout.o.d -c -o perout.o perout.c                                                           
cc -O3 -fPIC -Wall  -MD -MP -MF .mqnic_sched_block.o.d -c -o mqnic_sched_block.o mqnic_sched_block.c                                   
cc -O3 -fPIC -Wall  -MD -MP -MF .mqnic_scheduler.o.d -c -o mqnic_scheduler.o mqnic_scheduler.c                                         
cc -O3 -fPIC -Wall  -MD -MP -MF .mqnic_clk_info.o.d -c -o mqnic_clk_info.o mqnic_clk_info.c                                            
cc -O3 -fPIC -Wall  -MD -MP -MF .mqnic_stats.o.d -c -o mqnic_stats.o mqnic_stats.c                                                     
cc -O3 -fPIC -Wall  -MD -MP -MF .reg_if.o.d -c -o reg_if.o reg_if.c                                                                    
cc -O3 -fPIC -Wall  -MD -MP -MF .reg_block.o.d -c -o reg_block.o reg_block.c                                                           
cc -O3 -fPIC -Wall  -MD -MP -MF .fpga_id.o.d -c -o fpga_id.o fpga_id.c                                                                 
cc -O3 -Wall -Ilib -Iinclude -MD -MP -MF .perout.d -Llib/mqnic perout.o timespec.o -o perout -lmqnic                                   
/usr/bin/ld: cannot find -lmqnic: No such file or directory
collect2: error: ld returned 1 exit status
make: *** [Makefile:54: perout] Error 1
make: *** Waiting for unfinished jobs....
ar rcs libmqnic.a mqnic.o mqnic_res.o mqnic_if.o mqnic_port.o mqnic_sched_block.o mqnic_scheduler.o mqnic_clk_info.o mqnic_stats.o reg_if.o reg_block.o fpga_id.o
make[1]: Leaving directory '/home/vlad/Projects/PERSONAL/corundum/lib/mqnic'
```

</details>

