### PR TITLE
modules/mqnic: update APIs for kernel >= 6.8 compatibility

### DIFF
--- a/modules/mqnic/mqnic_dev.c
+++ b/modules/mqnic/mqnic_dev.c
@@ -134,7 +134,7 @@ static long mqnic_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 			info.child = 0;
 			info.size = mqnic->hw_regs_size;
 			info.offset = ((u64)info.index) << 40;
-			strlcpy(info.name, "ctrl", sizeof(info.name));
+			strscpy(info.name, "ctrl", sizeof(info.name));
 			break;
 		case 1:
 			info.type = MQNIC_REGION_TYPE_APP_CTRL;
@@ -142,7 +142,7 @@ static long mqnic_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 			info.child = 0;
 			info.size = mqnic->app_hw_regs_size;
 			info.offset = ((u64)info.index) << 40;
-			strlcpy(info.name, "app", sizeof(info.name));
+			strscpy(info.name, "app", sizeof(info.name));
 			break;
 		case 2:
 			info.type = MQNIC_REGION_TYPE_RAM;
@@ -150,7 +150,7 @@ static long mqnic_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 			info.child = 0;
 			info.size = mqnic->ram_hw_regs_size;
 			info.offset = ((u64)info.index) << 40;
-			strlcpy(info.name, "ram", sizeof(info.name));
+			strscpy(info.name, "ram", sizeof(info.name));
 			break;
 		default:
 			return -EINVAL;

--- a/modules/mqnic/mqnic_ethtool.c
+++ b/modules/mqnic/mqnic_ethtool.c
@@ -242,6 +242,23 @@ static int mqnic_set_rxfh(struct net_device *ndev, const u32 *indir,
 	return mqnic_update_indir_table(ndev);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+static int mqnic_get_rxfh_new(struct net_device *ndev, struct ethtool_rxfh_param *param)
+{
+    u8 hfunc = 0;
+    int ret = mqnic_get_rxfh(ndev, param->indir, param->key, &hfunc);
+    if (ret)
+        return ret;
+    param->hfunc = hfunc;
+    return 0;
+}
+
+static int mqnic_set_rxfh_new(struct net_device *ndev, struct ethtool_rxfh_param *param, struct netlink_ext_ack *extack)
+{
+    return mqnic_set_rxfh(ndev, param->indir, param->key, param->hfunc);
+}
+#endif
+
 static void mqnic_get_channels(struct net_device *ndev,
 		struct ethtool_channels *channel)
 {
@@ -305,8 +322,13 @@ static int mqnic_set_channels(struct net_device *ndev,
 	return ret;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static int mqnic_get_ts_info(struct net_device *ndev,
+		struct kernel_ethtool_ts_info *info)
+#else
 static int mqnic_get_ts_info(struct net_device *ndev,
 		struct ethtool_ts_info *info)
+#endif
 {
 	struct mqnic_priv *priv = netdev_priv(ndev);
 	struct mqnic_dev *mdev = priv->mdev;
@@ -612,8 +634,13 @@ const struct ethtool_ops mqnic_ethtool_ops = {
 	.set_pauseparam = mqnic_set_pauseparam,
 	.get_rxnfc = mqnic_get_rxnfc,
 	.get_rxfh_indir_size = mqnic_get_rxfh_indir_size,
-	.get_rxfh = mqnic_get_rxfh,
-	.set_rxfh = mqnic_set_rxfh,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+    .get_rxfh = mqnic_get_rxfh_new,
+    .set_rxfh = mqnic_set_rxfh_new,
+#else
+    .get_rxfh = mqnic_get_rxfh,
+    .set_rxfh = mqnic_set_rxfh,
+#endif
 	.get_channels = mqnic_get_channels,
 	.set_channels = mqnic_set_channels,
 	.get_ts_info = mqnic_get_ts_info,

--- a/modules/mqnic/mqnic_main.c
+++ b/modules/mqnic/mqnic_main.c
@@ -845,7 +845,11 @@ fail:
 	return ret;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+static void mqnic_platform_remove(struct platform_device *pdev)
+#else
 static int mqnic_platform_remove(struct platform_device *pdev)
+#endif
 {
 	struct mqnic_dev *mqnic = platform_get_drvdata(pdev);
 	struct devlink *devlink = priv_to_devlink(mqnic);
@@ -856,7 +860,11 @@ static int mqnic_platform_remove(struct platform_device *pdev)
 
 	mqnic_free_id(mqnic);
 	mqnic_devlink_free(devlink);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0)
+	return;
+#else
 	return 0;
+#endif
 }
 
 static struct platform_driver mqnic_platform_driver = {


### PR DESCRIPTION
This pull request improves the mqnic driver’s compatibility with recent Linux kernel versions, specifically:

- ethtool RXFH API compatibility:

Added support for the new ethtool RXFH API introduced in Linux kernel 6.8. The new mqnic_get_rxfh_new and mqnic_set_rxfh_new functions internally call the legacy implementations to avoid code duplication. The correct function is selected using #if LINUX_VERSION_CODE in the ethtool_ops structure.

- Platform driver remove callback:

Updated the mqnic_platform_remove function and its registration to handle the signature change (from int to void return type) introduced in Linux kernel 6.11, using conditional compilation.

These changes ensure the driver builds and functions correctly on both older and newer Linux kernels.